### PR TITLE
Issue 636 Hide Internal Keypaths

### DIFF
--- a/services/editor/src/pages/keys/components/KeysList/KeysList.js
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import { Observable } from 'rxjs';
 import { componentFromStream, createEventHandler } from 'recompose';
 import * as SearchService from '../../../../services/search-service';
-import fetch from '../../../../utils/fetch';
 import DirectoryTreeView from './DirectoryTreeView';
 import './KeysList.css';
 

--- a/services/editor/src/services/search-service.js
+++ b/services/editor/src/services/search-service.js
@@ -2,6 +2,23 @@
 
 import fetch from '../utils/fetch';
 let maxResults;
+let showInternalKeys;
+
+export const filterInternalKeys = async list =>
+  list && !await shouldShowInternalKeys() ? list.filter(x => !/^@tweek\//.test(x)) : list;
+
+const shouldShowInternalKeys = async () => {
+  if (showInternalKeys === undefined) {
+    try {
+      const response = await fetch('/api/editor-configuration/show_internal_keys');
+      showInternalKeys = await response.json();
+    } catch (err) {
+      console.error("unable to get 'show_internal_keys' configuration", err);
+    }
+  }
+
+  return showInternalKeys;
+};
 
 const createSearchFunction = endpoint =>
   async function suggestions(query) {
@@ -22,7 +39,10 @@ const createSearchFunction = endpoint =>
         credentials: 'same-origin',
       },
     );
-    return await response.json();
+
+    const results = await response.json();
+
+    return endpoint === 'search' ? results : filterInternalKeys(results);
   };
 
 export const getSuggestions = createSearchFunction('suggestions');

--- a/services/editor/src/services/search-service.js
+++ b/services/editor/src/services/search-service.js
@@ -16,7 +16,6 @@ const shouldShowInternalKeys = async () => {
       console.error("unable to get 'show_internal_keys' configuration", err);
     }
   }
-
   return showInternalKeys;
 };
 
@@ -39,12 +38,11 @@ const createSearchFunction = endpoint =>
         credentials: 'same-origin',
       },
     );
-
-    const results = await response.json();
-
-    return endpoint === 'search' ? results : filterInternalKeys(results);
+    return await response.json();
   };
 
-export const getSuggestions = createSearchFunction('suggestions');
+const suggestionFn = createSearchFunction('suggestions');
+
+export const getSuggestions = async query => filterInternalKeys(await suggestionFn(query));
 
 export const search = createSearchFunction('search');


### PR DESCRIPTION
closes #636 

moved filtering of internal keys (**@tweek**) to `search-service`.  Will now filter internal keys on all **suggestion** searches.  Will not filter on **search** searches since people still need to alter **@tweek** keys.

Added filtering to NewKeyInput so @tweek doesn't show.

Modified KeysList to call the filterInternalKeys from service instead of inline.