### PR TITLE
Fix empty override key scenario

### DIFF
--- a/core/Engine/Tweek.Engine.Tests/EngineTests.cs
+++ b/core/Engine/Tweek.Engine.Tests/EngineTests.cs
@@ -383,7 +383,25 @@ namespace Tweek.Engine.Tests
             });
         }
 
+        [Fact]
+        public async Task EmptyFixedKeyIsIgnoredInScan()
+        {
 
+            contexts = ContextCreator.Merge(ContextCreator.Create("device", "1", Tuple.Create("@fixed:", JsonValue.NewString("FixedValue"))));
+
+            paths = new[] { "abc/somepath" };
+            rules = rules = new Dictionary<string, RuleDefinition>
+            {
+                ["abc/somepath"] = JPadGenerator.New().AddSingleVariantRule(matcher: "{}", value: "SomeValue").Generate()
+            };
+
+
+            await Run(async (tweek, context) =>
+            {
+                var val = await tweek.GetContextAndCalculate("_", new HashSet<Identity> { new Identity("device", "1")}, context);
+                Assert.Equal("SomeValue", val["abc/somepath"].Value.AsString());
+            });
+        }
 
     }
 }

--- a/core/Engine/Tweek.Engine/Api.cs
+++ b/core/Engine/Tweek.Engine/Api.cs
@@ -56,6 +56,7 @@ namespace Tweek.Engine
             var contextPaths = pathQuery.Any(x => x.IsScan) ? allContextData.Values.SelectMany(x => x.Keys)
                 .Where(x => x.Contains("@fixed:"))
                 .Select(x => x.Split(':')[1])
+                .Where(x=> !String.IsNullOrEmpty(x))
                 .Select(ConfigurationPath.New).ToArray() : null;
 
 

--- a/services/editor/src/pages/context/components/FixedKeys/FixedKeysList/FixedKey/FixedKey.js
+++ b/services/editor/src/pages/context/components/FixedKeys/FixedKeysList/FixedKey/FixedKey.js
@@ -101,7 +101,7 @@ const NewFixedKeyComponent = ({ appendKey, keyPath, local: value, ...props }) =>
     className="new-fixed-key"
     data-comp="new-fixed-key"
     onKeyUpCapture={(e) => {
-      if (e.keyCode !== 13 || keyPath === '' || value === '') return;
+      if (e.keyCode !== 13) return;
       appendKey();
     }}
   >
@@ -117,6 +117,7 @@ export const NewFixedKey = compose(
   }),
   mapProps(({ appendKey, reset, value: local, keyPath, ...props }) => ({
     appendKey: () => {
+      if (keyPath === '' || local === '') return;
       appendKey({ keyPath, value: local });
       reset();
     },


### PR DESCRIPTION
- fix in editor preventing adding empty override key
- fix in api ignoring empty keys when getting values

closes #783 