### PR TITLE
Experimental - add support for card view for keys search

### DIFF
--- a/e2e/ui/spec/keys/delete-key.js
+++ b/e2e/ui/spec/keys/delete-key.js
@@ -16,9 +16,8 @@ const deleteKey = dataComp('delete-key');
 const keyMessage = dataComp('key-message');
 
 const assertKeyDeleted = keyName => {
-  KeysList.assertInList(keyName, true);
-
   authoringClient.waitForKeyToBeDeleted(keyName);
+  KeysList.assertInList(keyName, true);
 
   Key.open(keyName, false);
 

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -43,7 +43,7 @@ class KeysList {
     }
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);
-    browser.waitForVisible(keyLinkSelector, 2000, reverse);
+    browser.waitForVisible(keyLinkSelector, 3000, reverse);
   }
 
   search(filter) {

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -43,7 +43,7 @@ class KeysList {
     }
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);
-    browser.waitForVisible(keyLinkSelector, 3000, reverse);
+    browser.waitForVisible(keyLinkSelector, 4000, reverse);
   }
 
   search(filter) {

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -39,7 +39,6 @@ class KeysList {
       browser.clickIfVisible(
         treeItem('data-folder-name', folder + '[data-is-collapsed=true]'),
         1000,
-        reverse,
       );
     }
 

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -43,7 +43,7 @@ class KeysList {
     }
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);
-    browser.waitForVisible(keyLinkSelector, 1000, reverse);
+    browser.waitForVisible(keyLinkSelector, 2000, reverse);
   }
 
   search(filter) {

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -38,12 +38,12 @@ class KeysList {
     for (const folder of keyFolders) {
       browser.clickIfVisible(
         treeItem('data-folder-name', folder + '[data-is-collapsed=true]'),
-        1000,
+        timeout,
       );
     }
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);
-    browser.waitForVisible(keyLinkSelector, 4000, reverse);
+    browser.waitForVisible(keyLinkSelector, timeout, reverse);
   }
 
   search(filter) {

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -20,7 +20,7 @@ class KeysList {
     const keyFolders = extractFolders(keyName);
 
     keyFolders.forEach(folder =>
-      browser.clickWhenVisible(
+      browser.clickIfVisible(
         treeItem('data-folder-name', folder) + '[data-is-collapsed=true]',
         timeout,
       ),

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -20,7 +20,10 @@ class KeysList {
     const keyFolders = extractFolders(keyName);
 
     keyFolders.forEach(folder =>
-      browser.clickWhenVisible(treeItem('data-folder-name', folder), timeout),
+      browser.clickWhenVisible(
+        treeItem('data-folder-name', folder) + '[data-is-collapsed=true]',
+        timeout,
+      ),
     );
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);

--- a/e2e/ui/utils/KeysList.js
+++ b/e2e/ui/utils/KeysList.js
@@ -36,7 +36,11 @@ class KeysList {
     const keyFolders = extractFolders(keyName);
 
     for (const folder of keyFolders) {
-      browser.clickIfVisible(treeItem('data-folder-name', folder), 1000, reverse);
+      browser.clickIfVisible(
+        treeItem('data-folder-name', folder + '[data-is-collapsed=true]'),
+        1000,
+        reverse,
+      );
     }
 
     const keyLinkSelector = treeItem('href', `/keys/${keyName}`);

--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-editor",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "dist/index.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/editor/spec/unit/store/ducks/selectedKey-spec.js
+++ b/services/editor/spec/unit/store/ducks/selectedKey-spec.js
@@ -55,7 +55,7 @@ describe('selectedKey', async () => {
   }
 
   beforeEach(() => {
-    dispatchMock = jest.fn(action => {
+    dispatchMock = jest.fn((action) => {
       if (isFunction(action)) {
         return action(
           dispatchMock,
@@ -81,6 +81,7 @@ describe('selectedKey', async () => {
             source: '',
           },
           manifest: {
+            key_path: keyNameToAdd,
             implementation: {
               type: 'file',
               format: 'jpad',
@@ -334,7 +335,9 @@ describe('selectedKey', async () => {
 
         const addedAction = dispatchMock.mock.calls.find(([action]) => action.type === KEY_ADDED);
         expect(addedAction).to.exist;
-        assertDispatchAction(addedAction[0], { type: KEY_ADDED, payload: keyNameToSave });
+        const action = addedAction[0];
+        expect(action.type, KEY_ADDED);
+        expect(action.payload).to.have.property('key_path', keyNameToSave);
 
         const pushAction = dispatchMock.mock.calls.find(
           ([action]) => action.type && action.type.startsWith('@@router'),

--- a/services/editor/src/pages/keys/components/KeyPage/KeyAddPage/NewKeyInput.js
+++ b/services/editor/src/pages/keys/components/KeyPage/KeyAddPage/NewKeyInput.js
@@ -18,11 +18,12 @@ function getKeyNameSuggestions(keysList) {
 
 const NewKeyInput = compose(
   connect(state => ({ keysList: state.keys })),
-  mapPropsStream(prop$ => {
+  mapPropsStream((prop$) => {
     const keysList$ = prop$
       .pluck('keysList')
       .distinctUntilChanged()
-      .switchMap(SearchService.filterInternalKeys);
+      .switchMap(SearchService.filterInternalKeys)
+      .map(dic => Object.keys(dic));
 
     return Observable.combineLatest(prop$, keysList$, (props, keysList) => ({
       ...props,
@@ -52,7 +53,7 @@ const NewKeyInput = compose(
           suggestions={suggestions}
           value={displayName}
           placeholder="Enter key full path"
-          onChange={text => {
+          onChange={(text) => {
             const validation = keyNameValidations(text, keysList);
             validation.isShowingHint = !validation.isValid;
             onChange(text, validation);

--- a/services/editor/src/pages/keys/components/KeysList/CardView.js
+++ b/services/editor/src/pages/keys/components/KeysList/CardView.js
@@ -1,9 +1,14 @@
 import React from 'react';
+import { pure } from 'recompose';
 import PropTypes from 'prop-types';
 
-export default function CardView({ items, renderItem, expandByDefault }) {
-  let Card = renderItem;
-  return <div className="card-results">{items.map(item => <Card {...item} />)}</div>;
+export default function CardView({ items, renderItem, selectedItem, itemSelector = x => x }) {
+  let Card = pure(renderItem);
+  return (
+    <div className="card-results">
+      {items.map(item => <Card selected={itemSelector(item) === selectedItem} {...item} />)}
+    </div>
+  );
 }
 
 CardView.propTypes = {

--- a/services/editor/src/pages/keys/components/KeysList/CardView.js
+++ b/services/editor/src/pages/keys/components/KeysList/CardView.js
@@ -3,14 +3,10 @@ import PropTypes from 'prop-types';
 
 export default function CardView({ items, renderItem, expandByDefault }) {
   let Card = renderItem;
-  return (
-    <div class="key-search" data-comp="keys-search-view">
-      {items.map(item => <Card {...item} />)}
-    </div>
-  );
+  return <div class="card-results">{items.map(item => <Card {...item} />)}</div>;
 }
 
 CardView.propTypes = {
-  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
   renderItem: PropTypes.func.isRequired,
 };

--- a/services/editor/src/pages/keys/components/KeysList/CardView.js
+++ b/services/editor/src/pages/keys/components/KeysList/CardView.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export default function CardView({ items, renderItem, expandByDefault }) {
   let Card = renderItem;
-  return <div class="card-results">{items.map(item => <Card {...item} />)}</div>;
+  return <div className="card-results">{items.map(item => <Card {...item} />)}</div>;
 }
 
 CardView.propTypes = {

--- a/services/editor/src/pages/keys/components/KeysList/CardView.js
+++ b/services/editor/src/pages/keys/components/KeysList/CardView.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function CardView({ items, renderItem, expandByDefault }) {
+  let Card = renderItem;
+  return (
+    <div class="key-search" data-comp="keys-search-view">
+      {items.map(item => <Card {...item} />)}
+    </div>
+  );
+}
+
+CardView.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  renderItem: PropTypes.func.isRequired,
+};

--- a/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
+++ b/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import R from 'ramda';
+import * as R from 'ramda';
 import PropTypes from 'prop-types';
 import { VelocityTransitionGroup } from 'velocity-react';
 import openedFolderIconSrc from './resources/Folder-icon-opened.svg';

--- a/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
+++ b/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
@@ -118,6 +118,7 @@ class TreeDirectory extends React.Component {
           className="key-folder-name"
           onClick={() => this.setState({ isCollapsed: !isCollapsed })}
           data-folder-name={fullPath}
+          data-is-collapsed={isCollapsed}
         >
           <img
             className="key-folder-icon"

--- a/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
+++ b/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { VelocityTransitionGroup } from 'velocity-react';
 import openedFolderIconSrc from './resources/Folder-icon-opened.svg';
 import closedFolderIconSrc from './resources/Folder-icon-closed.svg';
+import { mapProps, compose, onlyUpdateForKeys, shallowEqual, shouldUpdate } from 'recompose';
 import './KeysList.css';
 
 const leaf = Symbol();
@@ -12,7 +13,7 @@ const compsPathSorter = (l, r) => {
   return l.props.name.localeCompare(r.props.name);
 };
 
-export default function DirectoryTreeView({ paths, renderItem, expandByDefault }) {
+export default function DirectoryTreeView({ paths, renderItem, selectedPath, expandByDefault }) {
   let pathTree = pathsToTree(paths);
   return (
     <div className="key-folder" data-comp="directory-tree-view">
@@ -22,6 +23,7 @@ export default function DirectoryTreeView({ paths, renderItem, expandByDefault }
             key={pathNode}
             name={pathNode}
             node={pathTree[pathNode]}
+            selectedPath={selectedPath}
             fullPath={pathNode}
             depth={1}
             expandByDefault={expandByDefault}
@@ -39,21 +41,34 @@ DirectoryTreeView.propTypes = {
   expandByDefault: PropTypes.bool,
 };
 
-function TreeNode({ node, name, fullPath, depth, renderItem, expandByDefault }) {
+const TreeNode = compose(
+  mapProps(({ selectedPath, fullPath, ...props }) => ({
+    selectedPath,
+    fullPath,
+    selected:
+      selectedPath && (fullPath === selectedPath || selectedPath.startsWith(`${fullPath}/`)),
+    ...props,
+  })),
+  shouldUpdate(
+    ({ selectedPath: _, ...oldProps }, { selectedPath: __, ...newProps }) =>
+      !shallowEqual(oldProps, newProps),
+  ),
+)(({ node, name, fullPath, depth, renderItem, expandByDefault, selected, selectedPath }) => {
   let LeafElement = renderItem;
 
   return node === leaf ? (
-    <LeafElement {...{ name, fullPath, depth }} />
+    <LeafElement {...{ name, fullPath, depth, selected }} />
   ) : (
     <TreeDirectory
       descendantsCount={countLeafsInTree(node)}
-      {...{ name, fullPath, depth, expandByDefault }}
+      {...{ name, selectedPath, fullPath, depth, selected, expandByDefault: expandByDefault }}
     >
       {Object.keys(node)
         .map(childPath => (
           <TreeNode
             key={childPath}
             name={childPath}
+            selectedPath={selectedPath}
             node={node[childPath]}
             fullPath={`${fullPath}/${childPath}`}
             depth={depth + 1}
@@ -64,7 +79,7 @@ function TreeNode({ node, name, fullPath, depth, renderItem, expandByDefault }) 
         .sort(compsPathSorter)}
     </TreeDirectory>
   );
-}
+});
 
 TreeNode.propTypes = {
   node: PropTypes.oneOfType([PropTypes.object, PropTypes.symbol]).isRequired,
@@ -88,7 +103,7 @@ class TreeDirectory extends React.Component {
     super(props);
 
     this.state = {
-      isCollapsed: !props.expandByDefault,
+      isCollapsed: !props.selected && !props.expandByDefault,
     };
   }
 
@@ -134,7 +149,11 @@ class TreeDirectory extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.expandByDefault !== nextProps.expandByDefault) {
+    if (!this.props.selected && nextProps.selected) {
+      this.setState({
+        isCollapsed: false,
+      });
+    } else if (this.props.expandByDefault !== nextProps.expandByDefault && !this.props.selected) {
       this.setState({
         isCollapsed: !nextProps.expandByDefault,
       });

--- a/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
+++ b/services/editor/src/pages/keys/components/KeysList/DirectoryTreeView.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import R from 'ramda';
 import PropTypes from 'prop-types';
 import { VelocityTransitionGroup } from 'velocity-react';
 import openedFolderIconSrc from './resources/Folder-icon-opened.svg';
 import closedFolderIconSrc from './resources/Folder-icon-closed.svg';
 import { mapProps, compose, onlyUpdateForKeys, shallowEqual, shouldUpdate } from 'recompose';
+
 import './KeysList.css';
 
 const leaf = Symbol();
@@ -51,7 +53,7 @@ const TreeNode = compose(
   })),
   shouldUpdate(
     ({ selectedPath: _, ...oldProps }, { selectedPath: __, ...newProps }) =>
-      !shallowEqual(oldProps, newProps),
+      !R.equals(oldProps, newProps),
   ),
 )(({ node, name, fullPath, depth, renderItem, expandByDefault, selected, selectedPath }) => {
   let LeafElement = renderItem;

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.css
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.css
@@ -110,7 +110,7 @@
   display: flex;
   margin-left: 5px;
   margin-top: 5px;
-  opacity: .7;
+  opacity: 0.7;
 }
 .key-folder .number-of-folder-keys:hover {
   cursor: pointer;
@@ -135,4 +135,64 @@
 .key-folder .sub-tree {
   display: flex;
   flex-grow: 1;
+}
+.key-search {
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-width: 400px;
+  min-width: 400px;
+}
+.key-search::-webkit-scrollbar {
+  width: 12px;
+}
+.key-search::-webkit-scrollbar-thumb {
+  border-radius: 6px;
+  background-color: #bcbbbb;
+  border: 3px solid #3a3e41;
+}
+.key-search::-webkit-scrollbar-track {
+  background-color: #3a3e41;
+  border-radius: 6px;
+}
+.key-search .key-card {
+  border-radius: 7px;
+  border: 2px solid grey;
+  box-sizing: border-box;
+  padding: 10px;
+  margin: 10px;
+  background-color: white;
+}
+.key-search .key-card a {
+  display: block;
+  min-height: 80px;
+  max-height: 160px;
+  text-decoration: none;
+  color: #515c66;
+  font-size: 12px;
+}
+.key-search .key-card .title {
+  font-size: 16px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: #515c66;
+}
+.key-search .key-card .tag {
+  font-size: 10px;
+  border-radius: 10px;
+  background-color: green;
+  padding: 4px;
+  color: white;
+  vertical-align: middle;
+}
+.key-search .key-card .path {
+  margin-top: 4px;
+  font-size: 10px;
+  color: #a5a5a5;
+}
+.key-search .key-card .description {
+  margin-top: 4px;
+}
+.key-search .key-card.selected {
+  border-color: #363a3e;
+  background-color: #eee ;
 }

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.css
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.css
@@ -8,11 +8,11 @@
   display: flex;
   flex-direction: column;
 }
-.keys-list-container .search-results .view-selector {
+.keys-list-container .view-selector {
   display: flex;
   min-height: 30px;
 }
-.keys-list-container .search-results .view-selector button {
+.keys-list-container .view-selector button {
   cursor: pointer;
   flex: 1;
 }

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.css
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.css
@@ -55,6 +55,14 @@
 .keys-list-container .search-input-wrapper .search-input:focus {
   border: none;
 }
+.keys-list-container .search-input-wrapper .clear {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  margin: 8px 0 ;
+  right: 10px;
+  cursor: pointer;
+}
 .keys-list-container .key-link-wrapper {
   display: flex;
   flex-grow: 1;

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.css
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.css
@@ -4,6 +4,18 @@
   flex-direction: column;
   background-color: transparent;
 }
+.keys-list-container .search-results {
+  display: flex;
+  flex-direction: column;
+}
+.keys-list-container .search-results .view-selector {
+  display: flex;
+  min-height: 30px;
+}
+.keys-list-container .search-results .view-selector button {
+  cursor: pointer;
+  flex: 1;
+}
 .keys-list-container .search-input-wrapper {
   background-color: transparent;
   border-bottom: solid 1px #363a3e;
@@ -69,23 +81,27 @@
 .keys-list-container .key-link-wrapper .key-link.selected {
   background-color: #686e74;
 }
-.key-folder {
+.keys-nav {
+  display: flex;
   overflow-y: auto;
   overflow-x: hidden;
   max-width: 400px;
   min-width: 400px;
 }
-.key-folder::-webkit-scrollbar {
+.keys-nav::-webkit-scrollbar {
   width: 12px;
 }
-.key-folder::-webkit-scrollbar-thumb {
+.keys-nav::-webkit-scrollbar-thumb {
   border-radius: 6px;
   background-color: #bcbbbb;
   border: 3px solid #3a3e41;
 }
-.key-folder::-webkit-scrollbar-track {
+.keys-nav::-webkit-scrollbar-track {
   background-color: #3a3e41;
   border-radius: 6px;
+}
+.key-folder {
+  width: 100%;
 }
 .key-folder .key-folder-name {
   font-size: 16px;
@@ -136,25 +152,10 @@
   display: flex;
   flex-grow: 1;
 }
-.key-search {
-  overflow-y: auto;
-  overflow-x: hidden;
-  max-width: 400px;
-  min-width: 400px;
+.search-results {
+  width: 100%;
 }
-.key-search::-webkit-scrollbar {
-  width: 12px;
-}
-.key-search::-webkit-scrollbar-thumb {
-  border-radius: 6px;
-  background-color: #bcbbbb;
-  border: 3px solid #3a3e41;
-}
-.key-search::-webkit-scrollbar-track {
-  background-color: #3a3e41;
-  border-radius: 6px;
-}
-.key-search .key-card {
+.search-results .key-card {
   border-radius: 7px;
   border: 2px solid grey;
   box-sizing: border-box;
@@ -162,7 +163,7 @@
   margin: 10px;
   background-color: white;
 }
-.key-search .key-card a {
+.search-results .key-card a {
   display: block;
   min-height: 80px;
   max-height: 160px;
@@ -170,29 +171,38 @@
   color: #515c66;
   font-size: 12px;
 }
-.key-search .key-card .title {
+.search-results .key-card .title {
   font-size: 16px;
+  display: inline-block;
+  color: #515c66;
   text-overflow: ellipsis;
   overflow: hidden;
-  color: #515c66;
+  white-space: nowrap;
+  max-width: 100%;
 }
-.key-search .key-card .tag {
+.search-results .key-card .tag {
   font-size: 10px;
   border-radius: 10px;
   background-color: green;
+  display: inline-block;
   padding: 4px;
+  margin: 0 2px;
   color: white;
   vertical-align: middle;
 }
-.key-search .key-card .path {
+.search-results .key-card .path {
   margin-top: 4px;
   font-size: 10px;
   color: #a5a5a5;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
 }
-.key-search .key-card .description {
+.search-results .key-card .description {
   margin-top: 4px;
 }
-.key-search .key-card.selected {
+.search-results .key-card.selected {
   border-color: #363a3e;
   background-color: #eee ;
 }

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.js
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.js
@@ -4,25 +4,41 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Observable } from 'rxjs';
-import { componentFromStream, createEventHandler } from 'recompose';
+import { componentFromStream, createEventHandler, withState } from 'recompose';
 import * as SearchService from '../../../../services/search-service';
 import DirectoryTreeView from './DirectoryTreeView';
 import CardView from './CardView';
 import './KeysList.css';
+import { relative } from 'path';
 
-function KeysFilter({ onFilterChange }) {
-  return (
-    <div className="search-input-wrapper">
+const KeysFilter = withState('filter', 'setFilter', '')(({ onFilterChange, setFilter, filter }) => (
+  <div className="search-input-wrapper">
+    <div style={{ position: 'relative' }}>
       <input
         data-comp="search-key-input"
         type="text"
         className="search-input"
         placeholder="Search..."
-        onKeyUp={e => onFilterChange(e.target.value)}
+        value={filter}
+        onChange={(e) => {
+          setFilter(e.target.value);
+          onFilterChange(e.target.value);
+        }}
       />
+      {filter !== '' && (
+        <button
+          className="clear"
+          onClick={(e) => {
+            setFilter('');
+            onFilterChange('');
+          }}
+        >
+          X
+        </button>
+      )}
     </div>
-  );
-}
+  </div>
+));
 
 const supportCardView = async () => {
   try {
@@ -36,24 +52,20 @@ const supportCardView = async () => {
   }
 };
 
-const KeyItem = connect((state, props) => ({
-  isActive: state.selectedKey && state.selectedKey.key && state.selectedKey.key === props.fullPath,
-}))(({ name, fullPath, depth, isActive }) => (
+const KeyItem = ({ name, fullPath, depth, selected }) => (
   <div className="key-link-wrapper" data-comp="key-link">
     <Link
-      className={classNames('key-link', { selected: isActive })}
+      className={classNames('key-link', { selected })}
       style={{ paddingLeft: (depth + 1) * 14 }}
       to={`/keys/${fullPath}`}
     >
       {name}
     </Link>
   </div>
-));
+);
 
-const CardItem = connect((state, props) => ({
-  isActive: state.selectedKey && state.selectedKey.key && state.selectedKey.key === props.key_path,
-}))(({ key_path, meta: { name, tags, description }, valueType, isActive }) => (
-  <div className={classNames('key-card', { selected: isActive })} data-comp="key-card">
+const CardItem = ({ key_path, meta: { name, tags, description }, valueType, selected }) => (
+  <div className={classNames('key-card', { selected })} data-comp="key-card">
     <Link title={key_path} className="key-link" to={`/keys/${key_path}`}>
       <div>
         <div className="title">{name}</div>
@@ -63,60 +75,79 @@ const CardItem = connect((state, props) => ({
       <div className="description">{description}</div>
     </Link>
   </div>
-));
+);
 
-const KeysList = componentFromStream((prop$) => {
-  const supportMultiResultsView$ = Observable.defer(supportCardView);
+const KeysList = connect((state, props) => ({
+  selectedKey: state.selectedKey && state.selectedKey.key,
+}))(
+  componentFromStream((prop$) => {
+    const supportMultiResultsView$ = Observable.defer(supportCardView);
 
-  const keyList$ = prop$
-    .map(x => x.keys)
-    .distinctUntilChanged()
-    .switchMap(async (allKeys) => {
-      const unarchivedKeys = R.filter(key => !key.meta.archived, allKeys);
-      return { keys: allKeys, visibleKeys: await SearchService.filterInternalKeys(unarchivedKeys) };
-    });
+    const keyList$ = prop$
+      .map(x => x.keys)
+      .distinctUntilChanged()
+      .switchMap(async (allKeys) => {
+        const unarchivedKeys = R.filter(key => !key.meta.archived, allKeys);
+        return {
+          keys: allKeys,
+          visibleKeys: await SearchService.filterInternalKeys(unarchivedKeys),
+        };
+      });
 
-  const { handler: setFilter, stream: filter$ } = createEventHandler();
-  const { handler: setResultsView, stream: resultsView$ } = createEventHandler();
+    const { handler: setFilter, stream: filter$ } = createEventHandler();
+    const { handler: setResultsView, stream: resultsView$ } = createEventHandler();
 
-  const filteredKeys$ = filter$
-    .map(x => x.trim())
-    .distinctUntilChanged()
-    .debounceTime(500)
-    .startWith('')
-    .switchMap(async filter => (filter === '' ? undefined : SearchService.search(filter)));
+    const filteredKeys$ = filter$
+      .map(x => x.trim())
+      .distinctUntilChanged()
+      .debounceTime(500)
+      .startWith('')
+      .switchMap(async filter => (filter === '' ? undefined : SearchService.search(filter)));
 
-  return Observable.combineLatest(
-    filteredKeys$,
-    keyList$,
-    supportMultiResultsView$,
-    resultsView$.startWith('cards'),
-  ).map(([filteredKeys, { visibleKeys, keys }, supportMultiResultsView, resultsView]) => (
-    <div className="keys-list-container">
-      <KeysFilter onFilterChange={setFilter} />
-      {filteredKeys &&
-        supportMultiResultsView && (
-          <div class="view-selector">
-            <button onClick={() => setResultsView('cards')}>List</button>
-            <button onClick={() => setResultsView('tree')}>Tree</button>
+    return Observable.combineLatest(
+      prop$.map(x => x.selectedKey).distinctUntilChanged(),
+
+      filteredKeys$,
+      keyList$,
+      supportMultiResultsView$,
+      resultsView$.startWith('cards'),
+    ).map(
+      (
+        [selectedKey, filteredKeys, { visibleKeys, keys }, supportMultiResultsView, resultsView],
+      ) => (
+        <div className="keys-list-container">
+          <KeysFilter onFilterChange={setFilter} />
+          {filteredKeys &&
+            supportMultiResultsView && (
+              <div class="view-selector">
+                <button onClick={() => setResultsView('cards')}>List</button>
+                <button onClick={() => setResultsView('tree')}>Tree</button>
+              </div>
+            )}
+          <div class="keys-nav">
+            <div class="search-results">
+              {filteredKeys && supportMultiResultsView && resultsView === 'cards' ? (
+                <CardView
+                  itemSelector={x => x && x.key_path}
+                  selectedItem={selectedKey}
+                  items={filteredKeys.map(x => keys[x]).filter(x => x)}
+                  renderItem={CardItem}
+                />
+              ) : (
+                <DirectoryTreeView
+                  selectedPath={selectedKey}
+                  paths={filteredKeys || Object.keys(visibleKeys)}
+                  expandByDefault={!!filteredKeys}
+                  renderItem={KeyItem}
+                />
+              )}
+            </div>
           </div>
-        )}
-      <div class="keys-nav">
-        <div class="search-results">
-          {filteredKeys && supportMultiResultsView && resultsView === 'cards' ? (
-            <CardView items={filteredKeys.map(x => keys[x]).filter(x => x)} renderItem={CardItem} />
-          ) : (
-            <DirectoryTreeView
-              paths={filteredKeys || Object.keys(visibleKeys)}
-              expandByDefault={!!filteredKeys}
-              renderItem={KeyItem}
-            />
-          )}
         </div>
-      </div>
-    </div>
-  ));
-});
+      ),
+    );
+  }),
+);
 
 KeysList.displayName = 'KeysList';
 

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.js
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as R from 'ramda';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -6,6 +7,7 @@ import { Observable } from 'rxjs';
 import { componentFromStream, createEventHandler } from 'recompose';
 import * as SearchService from '../../../../services/search-service';
 import DirectoryTreeView from './DirectoryTreeView';
+import CardView from './CardView';
 import './KeysList.css';
 
 function KeysFilter({ onFilterChange }) {
@@ -36,11 +38,28 @@ const KeyItem = connect((state, props) => ({
   </div>
 ));
 
+const CardItem = connect((state, props) => ({
+  isActive: state.selectedKey && state.selectedKey.key && state.selectedKey.key === props.key_path,
+}))(({ key_path, meta: { name, tags, description }, valueType, isActive }) => (
+  <div className={classNames('key-card', { selected: isActive })} data-comp="key-card">
+    <Link className="key-link" to={`/keys/${key_path}`}>
+      <div className="title">
+        {name} {(tags || []).map(x => <span className="tag">{x}</span>)}
+      </div>
+      <div className="path">{key_path}</div>
+      <div className="description">{description}</div>
+    </Link>
+  </div>
+));
+
 const KeysList = componentFromStream((prop$) => {
   const keyList$ = prop$
     .map(x => x.keys)
     .distinctUntilChanged()
-    .switchMap(SearchService.filterInternalKeys);
+    .switchMap(async (allKeys) => {
+      const unarchivedKeys = R.filter(key => !key.meta.archived, allKeys);
+      return { keys: allKeys, visibleKeys: await SearchService.filterInternalKeys(unarchivedKeys) };
+    });
 
   const { handler: setFilter, stream: filter$ } = createEventHandler();
   const filteredKeys$ = filter$
@@ -50,16 +69,18 @@ const KeysList = componentFromStream((prop$) => {
     .startWith('')
     .switchMap(async filter => (filter === '' ? undefined : SearchService.search(filter)));
 
-  return Observable.combineLatest(filteredKeys$, keyList$).map(([filteredKeys, keys]) => (
-    <div className="keys-list-container">
-      <KeysFilter onFilterChange={setFilter} />
-      <DirectoryTreeView
-        paths={filteredKeys || keys}
-        renderItem={KeyItem}
-        expandByDefault={!!filteredKeys}
-      />
-    </div>
-  ));
+  return Observable.combineLatest(filteredKeys$, keyList$).map(
+    ([filteredKeys, { visibleKeys, keys }]) => (
+      <div className="keys-list-container">
+        <KeysFilter onFilterChange={setFilter} />
+        {filteredKeys ? (
+          <CardView items={filteredKeys.map(x => keys[x]).filter(x => x)} renderItem={CardItem} />
+        ) : (
+          <DirectoryTreeView paths={Object.keys(visibleKeys)} renderItem={KeyItem} />
+        )}
+      </div>
+    ),
+  );
 });
 
 KeysList.displayName = 'KeysList';

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.js
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.js
@@ -27,12 +27,12 @@ function KeysFilter({ onFilterChange }) {
 const supportCardView = async () => {
   try {
     const response = await fetch(
-      `/api/editor-configuration/experimental/keys_search/display_cards_view`,
+      `/api/editor-configuration/experimental/keys_search/enable_cards_view`,
     );
     return await response.json();
   } catch (err) {
-    console.warn('failed to retrieve configuration for display_cards_view', err);
-    return null;
+    console.warn('failed to retrieve configuration for enable_cards_view', err);
+    return false;
   }
 };
 
@@ -94,30 +94,25 @@ const KeysList = componentFromStream((prop$) => {
   ).map(([filteredKeys, { visibleKeys, keys }, supportMultiResultsView, resultsView]) => (
     <div className="keys-list-container">
       <KeysFilter onFilterChange={setFilter} />
-      <div class="keys-nav">
-        {filteredKeys && supportMultiResultsView ? (
-          <div class="search-results">
-            <div class="view-selector">
-              <button onClick={() => setResultsView('cards')}>List</button>
-              <button onClick={() => setResultsView('tree')}>Tree</button>
-            </div>
-            {resultsView === 'cards' && (
-              <CardView
-                items={filteredKeys.map(x => keys[x]).filter(x => x)}
-                renderItem={CardItem}
-              />
-            )}
-            {resultsView === 'tree' && (
-              <DirectoryTreeView paths={filteredKeys} expandByDefault={true} renderItem={KeyItem} />
-            )}
+      {filteredKeys &&
+        supportMultiResultsView && (
+          <div class="view-selector">
+            <button onClick={() => setResultsView('cards')}>List</button>
+            <button onClick={() => setResultsView('tree')}>Tree</button>
           </div>
-        ) : (
-          <DirectoryTreeView
-            paths={filteredKeys || Object.keys(visibleKeys)}
-            expandByDefault={!!filteredKeys}
-            renderItem={KeyItem}
-          />
         )}
+      <div class="keys-nav">
+        <div class="search-results">
+          {filteredKeys && supportMultiResultsView && resultsView === 'cards' ? (
+            <CardView items={filteredKeys.map(x => keys[x]).filter(x => x)} renderItem={CardItem} />
+          ) : (
+            <DirectoryTreeView
+              paths={filteredKeys || Object.keys(visibleKeys)}
+              expandByDefault={!!filteredKeys}
+              renderItem={KeyItem}
+            />
+          )}
+        </div>
       </div>
     </div>
   ));

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.less
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.less
@@ -17,13 +17,14 @@
   .search-results{
     display: flex;
     flex-direction: column;
-    .view-selector{
-      display: flex;
-      min-height: 30px;
-      button{
-        cursor: pointer;
-        flex: 1
-      }
+  }
+
+  .view-selector{
+    display: flex;
+    min-height: 30px;
+    button{
+      cursor: pointer;
+      flex: 1
     }
   }
 

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.less
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.less
@@ -1,7 +1,7 @@
 @import (reference) "../../../../styles/core/core.less";
-@sidebarBgColor:#414b53;
+@sidebarBgColor: #414b53;
 
-.keys-list-container {  
+.keys-list-container {
   display: flex;
   color: #d8d8d8;
   flex-direction: column;
@@ -23,10 +23,9 @@
       background-color: #ffffff;
       padding-left: 40px;
       font-size: 18px;
-      &:focus{
+      &:focus {
         border: none;
       }
-
     }
   }
   .key-link-wrapper {
@@ -57,66 +56,129 @@
   }
 }
 .key-folder {
-    overflow-y: auto;
-    &::-webkit-scrollbar {
-      width: 12px;
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background-color: #bcbbbb;
+    border: 3px solid #3a3e41;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #3a3e41;
+    border-radius: 6px;
+  }
+  overflow-x: hidden;
+  max-width: 400px;
+  min-width: 400px;
+  .key-folder-name {
+    font-size: 16px;
+    display: flex;
+    flex-grow: 1;
+    height: 30px;
+    padding-left: 5px;
+    padding-top: 13px;
+    color: #d8d8d8;
+    background-color: transparent;
+    .transitioned();
+    &:hover {
+      cursor: pointer;
+      background-color: #363a3e;
     }
-    &::-webkit-scrollbar-thumb {
-      border-radius: 6px;
-      background-color: #bcbbbb;
-      border: 3px solid #3a3e41;
-    }
-    &::-webkit-scrollbar-track {
-      background-color: #3a3e41;
-      border-radius: 6px;
-    }
-    overflow-x: hidden;
-    max-width: 400px;
-    min-width: 400px;
-    .key-folder-name {
-      font-size: 16px;
-      display: flex;
-      flex-grow: 1;
-      height: 30px;
-      padding-left: 5px;
-      padding-top: 13px;
-      color: #d8d8d8;
-      background-color: transparent;
-      .transitioned();
-      &:hover {
-        cursor: pointer;
-        background-color: #363a3e;
-      }
-      &:active {
-        background-color: #363a3e;
-      }
-    }
-    .number-of-folder-keys {
-      font-size: 11px;
-      display: flex;
-      margin-left: 5px;
-      margin-top: 5px;
-      opacity: .7;
-      &:hover {
-        cursor: pointer;
-      }
-    }
-    .key-folder-icon {
-      width: 16px;
-      margin-right: 5px;
-      margin-bottom: 10px;
-      .user-select(none);
-      display: inline-block;
-      &:hover {
-        cursor: pointer;
-      }
-    }
-    .folder-items {
-      display: flex;
-      flex-grow: 1;
-    }
-    .sub-tree {
-      display: flex;
-      flex-grow: 1;
+    &:active {
+      background-color: #363a3e;
     }
   }
+  .number-of-folder-keys {
+    font-size: 11px;
+    display: flex;
+    margin-left: 5px;
+    margin-top: 5px;
+    opacity: 0.7;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  .key-folder-icon {
+    width: 16px;
+    margin-right: 5px;
+    margin-bottom: 10px;
+    .user-select(none);
+    display: inline-block;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  .folder-items {
+    display: flex;
+    flex-grow: 1;
+  }
+  .sub-tree {
+    display: flex;
+    flex-grow: 1;
+  }
+}
+.key-search{
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background-color: #bcbbbb;
+    border: 3px solid #3a3e41;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #3a3e41;
+    border-radius: 6px;
+  }
+  overflow-x: hidden;
+  max-width: 400px;
+  min-width: 400px;
+
+  .key-card{
+    border-radius: 7px;
+    border: 2px solid grey;
+    box-sizing: border-box;
+    padding: 10px;
+    margin: 10px;
+    background-color: white;
+    a{
+      display: block;
+      min-height: 80px;
+      max-height: 160px;
+      text-decoration: none;
+      color: #515c66;
+      font-size:12px;
+    }
+    .title{
+      font-size:16px;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      color: #515c66;
+    }
+    .tag{
+      font-size: 10px;
+      border-radius: 10px;
+      background-color: green;
+      padding: 4px;
+      color: white;
+      vertical-align: middle;
+    }
+    .path{
+      margin-top: 4px;
+      font-size: 10px;
+      color: #a5a5a5;
+    }
+    .description{
+      margin-top: 4px;
+    }
+
+    &.selected{ 
+      border-color:#363a3e;
+      background-color:#eee ;
+    }
+  }
+}
+

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.less
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.less
@@ -48,6 +48,14 @@
         border: none;
       }
     }
+    .clear{
+      position: absolute;
+      top:0;
+      bottom: 0;
+      margin: 8px 0 ;
+      right: 10px;
+      cursor: pointer;
+    }
   }
   .key-link-wrapper {
     display: flex;

--- a/services/editor/src/pages/keys/components/KeysList/KeysList.less
+++ b/services/editor/src/pages/keys/components/KeysList/KeysList.less
@@ -1,11 +1,31 @@
 @import (reference) "../../../../styles/core/core.less";
 @sidebarBgColor: #414b53;
 
+.hideLongLine(){
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
 .keys-list-container {
   display: flex;
   color: #d8d8d8;
   flex-direction: column;
   background-color: transparent;
+
+  .search-results{
+    display: flex;
+    flex-direction: column;
+    .view-selector{
+      display: flex;
+      min-height: 30px;
+      button{
+        cursor: pointer;
+        flex: 1
+      }
+    }
+  }
 
   .search-input-wrapper {
     background-color: transparent;
@@ -55,7 +75,9 @@
     }
   }
 }
-.key-folder {
+
+.keys-nav{
+  display: flex;
   overflow-y: auto;
   &::-webkit-scrollbar {
     width: 12px;
@@ -72,6 +94,10 @@
   overflow-x: hidden;
   max-width: 400px;
   min-width: 400px;
+}
+
+.key-folder {
+  width: 100%;
   .key-folder-name {
     font-size: 16px;
     display: flex;
@@ -119,24 +145,10 @@
     flex-grow: 1;
   }
 }
-.key-search{
-  overflow-y: auto;
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-  &::-webkit-scrollbar-thumb {
-    border-radius: 6px;
-    background-color: #bcbbbb;
-    border: 3px solid #3a3e41;
-  }
-  &::-webkit-scrollbar-track {
-    background-color: #3a3e41;
-    border-radius: 6px;
-  }
-  overflow-x: hidden;
-  max-width: 400px;
-  min-width: 400px;
 
+
+.search-results{
+  width: 100%;
   .key-card{
     border-radius: 7px;
     border: 2px solid grey;
@@ -154,15 +166,17 @@
     }
     .title{
       font-size:16px;
-      text-overflow: ellipsis;
-      overflow: hidden;
+      display: inline-block;
       color: #515c66;
+      .hideLongLine();
     }
     .tag{
       font-size: 10px;
       border-radius: 10px;
       background-color: green;
+      display: inline-block;
       padding: 4px;
+      margin: 0 2px;
       color: white;
       vertical-align: middle;
     }
@@ -170,6 +184,7 @@
       margin-top: 4px;
       font-size: 10px;
       color: #a5a5a5;
+      .hideLongLine();
     }
     .description{
       margin-top: 4px;

--- a/services/editor/src/services/search-service.js
+++ b/services/editor/src/services/search-service.js
@@ -1,11 +1,13 @@
 /* global fetch */
-
+import * as R from 'ramda';
 import fetch from '../utils/fetch';
 let maxResults;
 let showInternalKeys;
 
 export const filterInternalKeys = async list =>
-  list && !await shouldShowInternalKeys() ? list.filter(x => !/^@tweek\//.test(x)) : list;
+  list && !await shouldShowInternalKeys()
+    ? R.filter(x => !/^@tweek\//.test(x.key_path), list)
+    : list;
 
 const shouldShowInternalKeys = async () => {
   if (showInternalKeys === undefined) {

--- a/services/editor/src/store/ducks/ducks-utils/blankKeyDefinition.js
+++ b/services/editor/src/store/ducks/ducks-utils/blankKeyDefinition.js
@@ -2,6 +2,7 @@ export const BLANK_KEY_NAME = '_blank';
 
 export function createBlankKeyManifest(keyName, implementation = { type: 'file', format: 'jpad' }) {
   const manifest = {
+    key_path: keyName,
     meta: {
       archived: false,
     },

--- a/services/editor/src/store/ducks/keys.js
+++ b/services/editor/src/store/ducks/keys.js
@@ -20,7 +20,7 @@ export function getKeys() {
     try {
       const result = await await fetch('/api/manifests');
       const manifests = await result.json();
-      const payload = manifests.reduce((acc, key) => ({ ...acc, [key.key_path]: key }), {});
+      const payload = R.indexBy(R.prop('key_path'), manifests);
       dispatch({ type: KEYS_UPDATED, payload });
     } catch (error) {
       dispatch(showError({ title: 'Failed to retrieve keys!', error }));

--- a/services/editor/src/store/ducks/keys.js
+++ b/services/editor/src/store/ducks/keys.js
@@ -20,7 +20,7 @@ export function getKeys() {
     try {
       const result = await await fetch('/api/manifests');
       const manifests = await result.json();
-      const payload = manifests.filter(m => !m.meta.archived).map(x => x.key_path);
+      const payload = manifests.reduce((acc, key) => ({ ...acc, [key.key_path]: key }), {});
       dispatch({ type: KEYS_UPDATED, payload });
     } catch (error) {
       dispatch(showError({ title: 'Failed to retrieve keys!', error }));
@@ -30,12 +30,9 @@ export function getKeys() {
 
 export default handleActions(
   {
-    [KEYS_UPDATED]: (state, action) => R.uniq(action.payload),
-    [KEY_ADDED]: (state, action) => R.uniq([...state, action.payload]),
-    [KEY_REMOVED]: (state, action) => {
-      const deletedKeyIndex = state.indexOf(action.payload);
-      return deletedKeyIndex < 0 ? state : R.remove(deletedKeyIndex, 1, state);
-    },
+    [KEYS_UPDATED]: (state, { payload }) => payload,
+    [KEY_ADDED]: (state, { payload }) => R.assoc(payload['key_path'], payload, state),
+    [KEY_REMOVED]: (state, { payload }) => R.dissoc(payload, state),
   },
   [],
 );

--- a/services/editor/src/store/ducks/selectedKey.js
+++ b/services/editor/src/store/ducks/selectedKey.js
@@ -36,7 +36,7 @@ const KEY_CLOSED = 'KEY_CLOSED';
 let historySince;
 
 function updateRevisionHistory(keyName) {
-  return async function(dispatch) {
+  return async function (dispatch) {
     try {
       if (!historySince) {
         const response = await fetch('/api/editor-configuration/history/since');
@@ -53,7 +53,7 @@ function updateRevisionHistory(keyName) {
 }
 
 function updateKeyDependents(keyName) {
-  return async function(dispatch) {
+  return async function (dispatch) {
     let dependents = {};
     try {
       dependents = await (await fetch(`/api/dependents/${keyName}`)).json();
@@ -85,7 +85,7 @@ function createImplementation({ manifest, implementation }) {
 }
 
 export function changeKeyFormat(newFormat) {
-  return function(dispatch) {
+  return function (dispatch) {
     dispatch({ type: KEY_FORMAT_CHANGED, payload: newFormat });
   };
 }
@@ -96,7 +96,7 @@ const confirmAddKeyAlert = {
 };
 
 export const addKey = shouldShowConfirmationScreen =>
-  continueGuard(shouldShowConfirmationScreen, confirmAddKeyAlert, dispatch => {
+  continueGuard(shouldShowConfirmationScreen, confirmAddKeyAlert, (dispatch) => {
     // update the state to empty key in order to skip on leave hook
     dispatch({ type: KEY_OPENED, payload: createBlankJPadKey() });
     // navigate and set defaults
@@ -105,7 +105,7 @@ export const addKey = shouldShowConfirmationScreen =>
   });
 
 export function addKeyDetails() {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const currentState = getState();
     if (!currentState.selectedKey.validation.isValid) {
       dispatch({ type: SHOW_KEY_VALIDATIONS });
@@ -117,7 +117,7 @@ export function addKeyDetails() {
 }
 
 export function openKey(key, { revision } = {}) {
-  return async function(dispatch) {
+  return async function (dispatch) {
     dispatch(downloadTags());
     try {
       await ContextService.refreshSchema();
@@ -202,7 +202,7 @@ const confirmArchievAlert = {
 };
 
 export function archiveKey(archived) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const { selectedKey: { key, local, remote } } = getState();
 
     if (!R.equals(local, remote) && !(await dispatch(showConfirm(confirmArchievAlert))).result)
@@ -215,7 +215,7 @@ export function archiveKey(archived) {
     if (archived) {
       dispatch(removeKeyFromList(key));
     } else {
-      dispatch(addKeyToList(key));
+      dispatch(addKeyToList(remote.manifest));
     }
     dispatch(updateRevisionHistory(key));
     dispatch(updateKeyDependents(key));
@@ -223,7 +223,7 @@ export function archiveKey(archived) {
 }
 
 export function changeKeyValidationState(newValidationState) {
-  return function(dispatch, getState) {
+  return function (dispatch, getState) {
     const currentValidationState = getState().selectedKey.validation;
     if (R.path(['const', 'isValid'], currentValidationState) !== newValidationState) {
       const payload = R.assocPath(['const', 'isValid'], newValidationState, currentValidationState);
@@ -233,7 +233,7 @@ export function changeKeyValidationState(newValidationState) {
 }
 
 export function changeKeyValueType(keyValueType) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const keyValueTypeValidation = keyValueTypeValidations(keyValueType);
     keyValueTypeValidation.isShowingHint = !keyValueTypeValidation.isValid;
 
@@ -253,7 +253,7 @@ export function changeKeyValueType(keyValueType) {
 }
 
 export function updateKeyPath(newKeyPath, validation) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const currentValidationState = getState().selectedKey.validation;
     const newValidation = {
       ...currentValidationState,
@@ -271,7 +271,7 @@ export function updateKeyName(newKeyName) {
 }
 
 export function saveKey() {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const currentState = getState();
     const { selectedKey: { local, key } } = currentState;
     const isNewKey = !!local.key;
@@ -288,7 +288,7 @@ export function saveKey() {
     dispatch(updateKeyDependents(savedKey));
 
     if (isNewKey) {
-      dispatch(addKeyToList(savedKey));
+      dispatch(addKeyToList(local.manifest));
       dispatch(push(`/keys/${savedKey}`));
     }
   };
@@ -302,7 +302,7 @@ const deleteKeyAlert = (key, aliases = []) => ({
 });
 
 export function deleteKey() {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const { selectedKey: { key, aliases } } = getState();
 
     if (!(await dispatch(showConfirm(deleteKeyAlert(key, aliases)))).result) return;
@@ -323,7 +323,7 @@ export function deleteKey() {
 }
 
 export function addAlias(alias) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     const { selectedKey: { key } } = getState();
 
     const manifest = createBlankKeyManifest(alias, { type: 'alias', key });
@@ -338,7 +338,7 @@ export function addAlias(alias) {
       return;
     }
 
-    dispatch(addKeyToList(alias));
+    dispatch(addKeyToList(manifest));
 
     const { selectedKey: { usedBy, aliases } } = getState();
     dispatch({
@@ -349,7 +349,7 @@ export function addAlias(alias) {
 }
 
 export function deleteAlias(alias) {
-  return async function(dispatch, getState) {
+  return async function (dispatch, getState) {
     if (!(await dispatch(showConfirm(deleteKeyAlert(alias)))).result) return;
 
     try {
@@ -373,12 +373,12 @@ export function deleteAlias(alias) {
 const setValidationHintsVisibility = (validationState, isShown) => {
   Object.values(validationState)
     .filter(x => typeof x === 'object')
-    .map(x => {
+    .map((x) => {
       setValidationHintsVisibility(x, isShown);
       return x;
     })
     .filter(x => x.isValid === false)
-    .forEach(x => {
+    .forEach((x) => {
       x.isShowingHint = isShown;
       setValidationHintsVisibility(x, isShown);
     });
@@ -519,7 +519,7 @@ const handleKeyDependents = (state, { payload: { keyName, usedBy, aliases } }) =
   };
 };
 
-const handleKeyAddingDetails = state => {
+const handleKeyAddingDetails = (state) => {
   const implementation = {
     type: state.local.manifest.implementation.type,
     source: JSON.stringify(
@@ -544,10 +544,8 @@ const handleKeyAddingDetails = state => {
   };
 };
 
-const handleKeyPathChange = (state, { payload }) => ({
-  ...state,
-  key: payload,
-});
+const handleKeyPathChange = (state, { payload }) =>
+  R.pipe(R.assoc('key', payload), R.assocPath(['local', 'manifest', 'key_path'], payload))(state);
 
 const handleKeyFormatChange = (state, { payload }) =>
   R.assocPath(['local', 'manifest', 'implementation'], payload, state);

--- a/services/editor/src/store/ducks/selectedKey.js
+++ b/services/editor/src/store/ducks/selectedKey.js
@@ -215,7 +215,7 @@ export function archiveKey(archived) {
     if (archived) {
       dispatch(removeKeyFromList(key));
     } else {
-      dispatch(addKeyToList(remote.manifest));
+      dispatch(addKeyToList(keyToSave.manifest));
     }
     dispatch(updateRevisionHistory(key));
     dispatch(updateKeyDependents(key));


### PR DESCRIPTION
This PR introduce cards view for keys search and add UI selector for switching between cards and tree view in search results.

This feature is still experimental and can be enabled using the key:
```@tweek/experimental/keys_search/enable_cards_view```

This PR also fix #616 (expansion, not focus) and will allow us to easier implement features like #549, #722 as this data is accessible now.