### PR TITLE
add support for untyped arrays in editor

### DIFF
--- a/e2e/ui/spec/keys/edit-key.js
+++ b/e2e/ui/spec/keys/edit-key.js
@@ -103,6 +103,7 @@ describe('edit keys', () => {
         };
 
         Key.open(keyName).editObjectInEditor(JSON.stringify(defaultValue));
+        Alert.save();
 
         expect(Key.goToSourceTab().source).to.deep.equal(expectedObjectKeySource);
       });

--- a/e2e/ui/spec/keys/edit-key.js
+++ b/e2e/ui/spec/keys/edit-key.js
@@ -83,7 +83,7 @@ describe('edit keys', () => {
           partitions: [],
           valueType: 'object',
           rules: [],
-          defaultValue: defaultValue,
+          defaultValue,
         };
 
         Key.open(keyName).editObjectInEditor(JSON.stringify(defaultValue));
@@ -94,16 +94,15 @@ describe('edit keys', () => {
 
       it('should succeed in editing an array JPad key', () => {
         const keyName = 'behavior_tests/edit_key/visual/edit_array_test';
-        const values = ['val', 'test'];
+        const defaultValue = ['val', 'test'];
         const expectedObjectKeySource = {
           partitions: [],
           valueType: 'array',
           rules: [],
-          defaultValue: values,
+          defaultValue,
         };
 
-        Key.open(keyName);
-        values.forEach(item => Key.addDefaultItem(item));
+        Key.open(keyName).editObjectInEditor(JSON.stringify(defaultValue));
 
         expect(Key.goToSourceTab().source).to.deep.equal(expectedObjectKeySource);
       });

--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-editor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/index.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/editor/src/components/common/Input/EditJSON.js
+++ b/services/editor/src/components/common/Input/EditJSON.js
@@ -17,18 +17,29 @@ const monacoOptions = {
   },
 };
 
+const getEmptyValue = (valueType) => {
+  let baseType = valueType.base || valueType.name;
+  if (baseType === 'array') {
+    return `[\n\t\n]`;
+  }
+  if (baseType === 'object') {
+    return `{\n\t\n}`;
+  }
+  return '';
+};
+
 export const withJsonEditor = compose(
   connect(null, {
     showCustomAlert,
   }),
   mapProps(({ onChange, showCustomAlert, ...props }) => {
-    const editJson = async (currentSource) => {
+    const editJson = async (currentSource, valueType) => {
       const saveButton = {
         text: 'Save',
         value: true,
         className: 'rodal-save-btn',
         'data-alert-button': 'save',
-        validate: data => isStringValidJson(data),
+        validate: data => isStringValidJson(data, valueType),
       };
 
       const editModal = {
@@ -40,7 +51,10 @@ export const withJsonEditor = compose(
                 <MonacoEditor
                   language="json"
                   value={
-                    data || (currentSource ? JSON.stringify(currentSource, null, 4) : `{\n\t\n}`)
+                    data ||
+                    (currentSource
+                      ? JSON.stringify(currentSource, null, 4)
+                      : getEmptyValue(valueType))
                   }
                   options={{ ...monacoOptions, readOnly: false }}
                   onChange={newSource => onChange(newSource)}

--- a/services/editor/src/components/common/Input/TypedInput.js
+++ b/services/editor/src/components/common/Input/TypedInput.js
@@ -49,10 +49,13 @@ const InputComponent = ({
   types,
   ...props
 }) => {
+  if (
+    valueTypeName === types.object.name ||
+    (valueTypeName === types.array.name && !valueType.ofType)
+  ) {
+    return <CodeEditor valueType={valueType} onChange={onChange} value={value} {...props} />;
+  }
   if (valueTypeName === types.array.name) {
-    if (!valueType.ofType || valueType.ofType === 'object') {
-      return <CodeEditor onChange={onChange} valueType={valueType} value={value} {...props} />;
-    }
     return (
       <ListTypedValue
         data-comp="property-value"
@@ -75,9 +78,7 @@ const InputComponent = ({
       />
     );
   }
-  if (valueTypeName === 'object') {
-    return <CodeEditor valueType={valueType} onChange={onChange} value={value} {...props} />;
-  }
+
   return <Input {...props} onChange={onChange} value={value} />;
 };
 

--- a/services/editor/src/components/common/Input/TypedInput.js
+++ b/services/editor/src/components/common/Input/TypedInput.js
@@ -50,7 +50,7 @@ const InputComponent = ({
   ...props
 }) => {
   if (valueTypeName === types.array.name) {
-    if (!valueType.ofType) {
+    if (!valueType.ofType || valueType.ofType === 'object') {
       return <CodeEditor onChange={onChange} valueType={valueType} value={value} {...props} />;
     }
     return (

--- a/services/editor/src/components/common/Input/TypedInput.js
+++ b/services/editor/src/components/common/Input/TypedInput.js
@@ -26,7 +26,13 @@ const valueToItem = value =>
 
 const CodeEditor = withJsonEditor(({ editJson, onChange, value, valueType, ...props }) => (
   <div>
-    <Input readOnly {...props} onChange={onChange} value={value ? JSON.stringify(value) : value} />
+    <Input
+      onDoubleClick={() => editJson(value, valueType)}
+      readOnly
+      {...props}
+      onChange={onChange}
+      value={value ? JSON.stringify(value) : value}
+    />
     <button
       className="text-input object-type-expander"
       data-comp="object-editor"

--- a/services/editor/src/components/common/Input/TypedInput.js
+++ b/services/editor/src/components/common/Input/TypedInput.js
@@ -24,17 +24,35 @@ export const getTypesService = getContext(typesServiceContextType);
 const valueToItem = value =>
   value === undefined || value === '' ? undefined : { label: changeCase.pascalCase(value), value };
 
+const CodeEditor = withJsonEditor(({ editJson, onChange, value, valueType, ...props }) => (
+  <div>
+    <Input
+      readOnly
+      {...props}
+      onChange={x => onChange(JSON.parse(x))}
+      value={value ? JSON.stringify(value) : value}
+    />
+    <button
+      className="text-input object-type-expander"
+      data-comp="object-editor"
+      onClick={() => editJson(value, valueType)}
+    />
+  </div>
+));
+
 const InputComponent = ({
   value,
   valueType,
   valueTypeName,
   allowedValues,
   onChange,
-  editJson,
   types,
   ...props
 }) => {
   if (valueTypeName === types.array.name) {
+    if (!valueType.ofType) {
+      return <CodeEditor onChange={onChange} valueType={valueType} value={value} {...props} />;
+    }
     return (
       <ListTypedValue
         data-comp="property-value"
@@ -58,21 +76,7 @@ const InputComponent = ({
     );
   }
   if (valueTypeName === 'object') {
-    return (
-      <div>
-        <Input
-          readOnly
-          {...props}
-          onChange={onChange}
-          value={value ? JSON.stringify(value) : value}
-        />
-        <button
-          className="text-input object-type-expander"
-          data-comp="object-editor"
-          onClick={() => editJson(value)}
-        />
-      </div>
-    );
+    return <CodeEditor valueType={valueType} onChange={onChange} value={value} {...props} />;
   }
   return <Input {...props} onChange={onChange} value={value} />;
 };
@@ -127,7 +131,6 @@ const TypedInput = compose(
       };
     },
   ),
-  withJsonEditor,
 )(InputWithIcon);
 
 TypedInput.propTypes = {

--- a/services/editor/src/components/common/Input/TypedInput.js
+++ b/services/editor/src/components/common/Input/TypedInput.js
@@ -26,12 +26,7 @@ const valueToItem = value =>
 
 const CodeEditor = withJsonEditor(({ editJson, onChange, value, valueType, ...props }) => (
   <div>
-    <Input
-      readOnly
-      {...props}
-      onChange={x => onChange(JSON.parse(x))}
-      value={value ? JSON.stringify(value) : value}
-    />
+    <Input readOnly {...props} onChange={onChange} value={value ? JSON.stringify(value) : value} />
     <button
       className="text-input object-type-expander"
       data-comp="object-editor"
@@ -53,7 +48,14 @@ const InputComponent = ({
     valueTypeName === types.object.name ||
     (valueTypeName === types.array.name && !valueType.ofType)
   ) {
-    return <CodeEditor valueType={valueType} onChange={onChange} value={value} {...props} />;
+    return (
+      <CodeEditor
+        valueType={valueType}
+        onChange={x => onChange(JSON.parse(x))}
+        value={value}
+        {...props}
+      />
+    );
   }
   if (valueTypeName === types.array.name) {
     return (

--- a/services/editor/src/services/types-service.js
+++ b/services/editor/src/services/types-service.js
@@ -35,7 +35,6 @@ export async function refreshTypes() {
 
 export function convertValue(value, targetType) {
   const type = typeof targetType === 'string' ? types[targetType] : targetType;
-
   if (!type) {
     throw new Error('Unknown type', targetType);
   }
@@ -48,6 +47,9 @@ export function convertValue(value, targetType) {
   case 'array':
     return convertCheckArray(value, type.ofType ? x => convertValue(x, type.ofType) : x => x);
   case 'object':
+    if (typeof value === types.object.name) {
+      return value;
+    }
     return safeConvertToBaseType(value, 'object');
   default:
     return value.toString();


### PR DESCRIPTION
For now, typedinput will fallback to json code editor for cases not easily expressed with tags. (untyped arrays, object arrays)