### PR TITLE
Publisher: try multiple times to clone the git repo at startup.

### DIFF
--- a/services/publishing/scripts/init-git.sh
+++ b/services/publishing/scripts/init-git.sh
@@ -52,9 +52,15 @@ mkdir -p $REPO_LOCATION
 chown git:git $REPO_LOCATION
 chown -R git:git /home/git
 cd $REPO_LOCATION
-# clone the source repository and apply hooks
+# Try 5 times to clone the source repository and apply hooks
 set -e
-su - git -s "/bin/bash" -c "cd `pwd` && source ~/.env && git clone --bare $GIT_UPSTREAM_URI ."
+
+for i in {1..5}
+do 
+    su - git -s "/bin/bash" -c "cd `pwd` && source ~/.env && git clone --bare $GIT_UPSTREAM_URI ." && wait && break
+    [[ $i -eq 5 ]] && exit 1 || sleep 10
+done
+
 cp /tweek/hooks/* $REPO_LOCATION/hooks/
 set +e
 


### PR DESCRIPTION
This is very useful when trying to launch Tweek on Kubernetes with Git Server (like in Play-With-Tweek).

The failed scenario is:
1. Publisher and Git Server launched together.
2. Publisher tries to clone from Git Server but it still not ready.
3. Publisher failed to start.
4. Kubernetes restart Publisher (Optional)

The fix makes the publisher try 5 times with 10 seconds of delay between each attempt.