### PR TITLE
disable v1 read/write api access by default repo

### DIFF
--- a/services/git-service/BareRepository/source/implementations/jpad/@tweek/auth/@global/read_configuration.jpad
+++ b/services/git-service/BareRepository/source/implementations/jpad/@tweek/auth/@global/read_configuration.jpad
@@ -2,5 +2,5 @@
     "partitions": [],
     "valueType": "string",
     "rules": [],
-    "defaultValue": "allow"
+    "defaultValue": "deny"
 }

--- a/services/git-service/BareRepository/source/implementations/jpad/@tweek/auth/@global/write_context.jpad
+++ b/services/git-service/BareRepository/source/implementations/jpad/@tweek/auth/@global/write_context.jpad
@@ -2,5 +2,5 @@
     "partitions": [],
     "valueType": "string",
     "rules": [],
-    "defaultValue": "allow"
+    "defaultValue": "deny"
 }


### PR DESCRIPTION
By creating a new default global policy, all v1 clients will be limited in reading/writing to tweek