### PR TITLE
Update appmetrics prometheus formatter

### DIFF
--- a/services/api/Tweek.ApiService/Tweek.ApiService.csproj
+++ b/services/api/Tweek.ApiService/Tweek.ApiService.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="App.Metrics.AspNetCore.Health" Version="2.0.0" />
     <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Json" Version="2.1.0" />
-    <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="2.0.0" />
+    <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Health.Checks.Http" Version="2.0.0" />
     <PackageReference Include="FSharpUtils.Newtonsoft.JsonValue" Version="0.2.6" />
     <PackageReference Include="LanguageExt.Core" Version="3.0.17" />

--- a/services/api/Tweek.ApiService/Tweek.ApiService.csproj
+++ b/services/api/Tweek.ApiService/Tweek.ApiService.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore.Health" Version="2.0.0" />
-    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="App.Metrics.Formatters.Json" Version="2.1.0" />
+    <PackageReference Include="App.Metrics.AspNetCore.Mvc" Version="3.0.0" />
+    <PackageReference Include="App.Metrics.Formatters.Json" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Health.Checks.Http" Version="2.0.0" />
     <PackageReference Include="FSharpUtils.Newtonsoft.JsonValue" Version="0.2.6" />

--- a/services/api/Tweek.ApiService/Tweek.ApiService.csproj
+++ b/services/api/Tweek.ApiService/Tweek.ApiService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <VersionPrefix>1.0.0-rc1</VersionPrefix>
+    <VersionPrefix>1.0.0-rc2</VersionPrefix>
     <DockerComposeProjectPath>..\..\..\deployments\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591, 1701, 1702, 1998</NoWarn>


### PR DESCRIPTION
Prometheus is now more strict about the metric capitalization. Issue
We should use the new version otherwise Prometheus version 2.4 and above will fail to scrape the metrics.