### PR TITLE
bumping versions for error page

### DIFF
--- a/services/api/Tweek.ApiService/Tweek.ApiService.csproj
+++ b/services/api/Tweek.ApiService/Tweek.ApiService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <VersionPrefix>1.0.0-rc4</VersionPrefix>
+    <VersionPrefix>1.0.0-rc5</VersionPrefix>
     <DockerComposeProjectPath>..\..\..\deployments\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591, 1701, 1702, 1998</NoWarn>

--- a/services/authoring/package.json
+++ b/services/authoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-authoring",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0-rc7",
   "main": "src/server.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-editor",
-  "version": "1.0.0-rc12",
+  "version": "1.0.0-rc13",
   "main": "dist/index.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/publishing/Tweek.Publishing.Service/Tweek.Publishing.Service.csproj
+++ b/services/publishing/Tweek.Publishing.Service/Tweek.Publishing.Service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <VersionPrefix>1.0.0-rc8</VersionPrefix>
+    <VersionPrefix>1.0.0-rc9</VersionPrefix>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>latest</LangVersion>
     <NoWarn>CS1998</NoWarn>


### PR DESCRIPTION
Bumping versions of editor, api, authoring and publishing, for the Error Page PR (https://github.com/Soluto/tweek/pull/1043)