### PR TITLE
Updated example policy for "every context"

### DIFF
--- a/docs/pages/4.security/02.examples.md
+++ b/docs/pages/4.security/02.examples.md
@@ -109,7 +109,7 @@ This file can be edited via the editor UI (settings/security/policies/acl)
             "contexts": {
               "*": "*"
             },
-            "object": "editors",
+            "object": "*",
             "action": "*",
             "effect": "allow"
         },


### PR DESCRIPTION
Mistake in the object field that should be "*"