### PR TITLE
Allow to set multiple couchbase bootstrap servers

### DIFF
--- a/CI/codefresh.yml
+++ b/CI/codefresh.yml
@@ -10,7 +10,7 @@ steps:
     repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
     revision: '${{CF_REVISION}}'
     git: github
-  
+
   build:
     type: parallel
     name: build
@@ -21,14 +21,14 @@ steps:
         title: Check versions to deploy
         image: alpine/git
         commands:
-          - ./CI/versions_to_deploy.sh ${{CF_VOLUME_PATH}}/env_vars_to_export  
+          - ./CI/versions_to_deploy.sh ${{CF_VOLUME_PATH}}/env_vars_to_export
 
       BuildingGateway:
         title: Building Gateway
         type: build
         image_name: soluto/tweek-gateway
         working_directory: ./services/gateway/
-              
+
       BuildingGitRepository:
         title: Building Git Repository Docker Image
         type: build
@@ -40,7 +40,7 @@ steps:
         type: build
         image_name: soluto/tweek-api
         dockerfile: TweekApi.Dockerfile
-      
+
       BuildingPublishing:
         title: Building Publishing Docker Image
         type: build
@@ -70,20 +70,20 @@ steps:
         type: build
         image_name: soluto/e2e-integration
         working_directory: ./e2e/integration
-      
+
       BuildingApiSmokeTestImage:
         title: Building Tweek Api Smoke Test Docker Image
         type: build
         image_name: soluto/tweek-api-smoke-tests
         dockerfile: TweekApiSmokeTest.Dockerfile
 
-  
+
   E2ETests:
     title: End2End Tests - integration, smoke & ui
     stage: test
     type: composition
     composition: ./CI/docker-compose.yml
-    composition_variables:      
+    composition_variables:
       - GATEWAY_IMAGE=${{BuildingGateway}}
       - REPOSITORY_IMAGE=${{BuildingGitRepository}}
       - PUBLISHING_IMAGE=${{BuildingPublishing}}
@@ -94,13 +94,13 @@ steps:
     composition_candidates:
       smoke-tests:
         image: ${{BuildingApiSmokeTestImage}}
-        depends_on: 
+        depends_on:
           - gateway
           - publishing
-        environment: 
+        environment:
           - TWEEK_API_URL=http://api/
         links:
-          - gateway:api      
+          - gateway:api
 
       e2e-integration:
         image: ${{BuildingIntegrationTests}}

--- a/addons/Context/Tweek.Drivers.Context.Couchbase/CouchBaseServiceAddon.cs
+++ b/addons/Context/Tweek.Drivers.Context.Couchbase/CouchBaseServiceAddon.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using App.Metrics.Health;
 using Couchbase;
 using Couchbase.Configuration.Client;
@@ -42,15 +43,15 @@ namespace Tweek.Drivers.Context.Couchbase
             var couchbaseConfig = configuration.GetSection("Couchbase");
             var contextBucketName = couchbaseConfig["BucketName"];
             var contextBucketPassword = couchbaseConfig["Password"];
-            var url = couchbaseConfig["Url"];
+            var serverUrls = couchbaseConfig.GetSection("Urls").Get<List<string>>();
             var healthCheckMaxLatency = Optional(couchbaseConfig["HealthCheck:MaxLatencyMilliseconds"]).Map(x=> TimeSpan.FromMilliseconds(int.Parse(x))).IfNone(TimeSpan.FromSeconds(1));
             var healthCheckRetry = Optional(couchbaseConfig["HealthCheck:RetryCount"]).Map(x=> int.Parse(x)).IfNone(3);
 
-            InitCouchbaseCluster(contextBucketName, contextBucketPassword, url);
+            InitCouchbaseCluster(contextBucketName, contextBucketPassword, serverUrls);
 
             var contextDriver = new CouchBaseDriver(ClusterHelper.GetBucket, contextBucketName);
             services.AddSingleton<IContextDriver>(contextDriver);
-            
+
             services.AddSingleton<HealthCheck>(ctx =>
             {
                 ctx.GetService<StaticCouchbaseDisposer>();
@@ -59,11 +60,11 @@ namespace Tweek.Drivers.Context.Couchbase
             services.AddSingleton<StaticCouchbaseDisposer>();
         }
 
-        private void InitCouchbaseCluster(string bucketName, string bucketPassword, string url)
+        private void InitCouchbaseCluster(string bucketName, string bucketPassword, IEnumerable<string> serverUrls)
         {
             ClusterHelper.Initialize(new ClientConfiguration
             {
-                Servers = new List<Uri> {new Uri(url)},
+                Servers = serverUrls.Select(url => new Uri(url)).ToList(),
                 BucketConfigs = new Dictionary<string, BucketConfiguration>
                 {
                     [bucketName] = new BucketConfiguration

--- a/addons/Context/Tweek.Drivers.Context.Couchbase/Tweek.Drivers.Context.Couchbase.csproj
+++ b/addons/Context/Tweek.Drivers.Context.Couchbase/Tweek.Drivers.Context.Couchbase.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="App.Metrics.Health.Abstractions" Version="3.1.0" />
-    <PackageReference Include="CouchbaseNetClient" Version="2.7.11" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.7.15" />
     <PackageReference Include="FSharpUtils.Newtonsoft.JsonValue" Version="0.2.6" />
     <PackageReference Include="System.Collections.Immutable" version="1.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" />

--- a/services/api/Tweek.ApiService/Tweek.ApiService.csproj
+++ b/services/api/Tweek.ApiService/Tweek.ApiService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <VersionPrefix>1.0.0-rc5</VersionPrefix>
+    <VersionPrefix>1.0.0-rc6</VersionPrefix>
     <DockerComposeProjectPath>..\..\..\deployments\docker-compose.dcproj</DockerComposeProjectPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591, 1701, 1702, 1998</NoWarn>


### PR DESCRIPTION
This PR allows to set multiple bootstrap servers for Couchbase db.

According to Couchbase documentation:

> The client attempts to bootstrap off of each of these servers. When it successfully connects with one of the servers in this list, the bootstrapping process ends.

So setting multiple servers from the cluster will improve connection stability in case of failure of the first server.