### PR TITLE
Added validation for nested keys

### DIFF
--- a/services/publishing/Tweek.Publishing.Service/Startup.cs
+++ b/services/publishing/Tweek.Publishing.Service/Startup.cs
@@ -165,6 +165,7 @@ namespace Tweek.Publishing.Service
                 {
                     (Patterns.Manifests, new CircularDependencyValidator()),
                     (Patterns.Manifests, new ManifestStructureValidator()),
+                    (Patterns.Manifests, new NestedKeysValidator()),
                     (Patterns.JPad, new CompileJPadValidator()),
                     (Patterns.SubjectExtractionRules, new SubjectExtractionValidator()),
                     (Patterns.Policy, new PolicyValidator()),

--- a/services/publishing/Tweek.Publishing.Service/Validation/NestedKeysValidator.cs
+++ b/services/publishing/Tweek.Publishing.Service/Validation/NestedKeysValidator.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using LanguageExt;
+using Newtonsoft.Json;
+using Tweek.Publishing.Service.Model.Rules;
+
+namespace Tweek.Publishing.Service.Validation
+{
+    public class NestedKeysValidator : IValidator
+    {
+        public async Task Validate(string filePath, Func<string, Task<string>> reader)
+        {
+            var currentFilePath = Path.GetDirectoryName(filePath);
+            
+            while (currentFilePath != "manifests")
+            {
+                try
+                {
+                    await reader(Path.ChangeExtension(currentFilePath, "json"));
+                    throw new NestedKeysException(filePath);
+                }
+                catch (Exception ex) when (!(ex is NestedKeysException)) 
+                {
+                    // File doesn't exist, all good
+                }
+                
+                currentFilePath = Path.GetDirectoryName(currentFilePath);
+            }
+        }
+    }
+    
+    public class NestedKeysException : Exception
+    {
+        public NestedKeysException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/services/publishing/Tweek.Publishing.Service/Validation/NestedKeysValidator.cs
+++ b/services/publishing/Tweek.Publishing.Service/Validation/NestedKeysValidator.cs
@@ -1,10 +1,6 @@
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
-using LanguageExt;
-using Newtonsoft.Json;
-using Tweek.Publishing.Service.Model.Rules;
 
 namespace Tweek.Publishing.Service.Validation
 {
@@ -14,7 +10,7 @@ namespace Tweek.Publishing.Service.Validation
         {
             var currentFilePath = Path.GetDirectoryName(filePath);
             
-            while (currentFilePath != "manifests")
+            while (currentFilePath != "manifests" && !string.IsNullOrEmpty(currentFilePath))
             {
                 try
                 {

--- a/services/publishing/Tweek.Publishing.Tests/Validation/NestedKeysValidatorTests.cs
+++ b/services/publishing/Tweek.Publishing.Tests/Validation/NestedKeysValidatorTests.cs
@@ -32,5 +32,34 @@ namespace Tweek.Publishing.Tests.Validation
             await Assert.ThrowsAsync<NestedKeysException>(() =>
                 validator.Validate("manifests/a/b.json", async x => files[x]));
         }
+        
+        [Fact]
+        public async Task FailsWhenDeepParentKeyExists()
+        {
+            var validator = new NestedKeysValidator();
+            var files = new Dictionary<string, string>
+            {
+                {"manifests/a/b.json", ""}
+            };
+
+            await Assert.ThrowsAsync<NestedKeysException>(() =>
+                validator.Validate("manifests/a/b/c/d/e/f.json", async x => files[x]));
+        }
+        
+        [Fact]
+        public async Task DoesntGoIntoAnInfiniteLoopInEdgeCasesOrBadInput()
+        {
+            var validator = new NestedKeysValidator();
+            var files = new Dictionary<string, string>
+            {
+                {"manifests/a/b.json", ""}
+            };
+
+            await validator.Validate("", async x => files[x]);
+            await validator.Validate("/something", async x => files[x]);
+            await validator.Validate("something", async x => files[x]);
+            await validator.Validate("/manifests", async x => files[x]);
+            await validator.Validate("/////", async x => files[x]);
+        }
     }
 }

--- a/services/publishing/Tweek.Publishing.Tests/Validation/NestedKeysValidatorTests.cs
+++ b/services/publishing/Tweek.Publishing.Tests/Validation/NestedKeysValidatorTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Tweek.Publishing.Service.Validation;
+using Xunit;
+
+namespace Tweek.Publishing.Tests.Validation
+{
+    public class NestedKeysValidatorTests
+    {
+        [Fact]
+        public async Task PassesWhenNoParentKey()
+        {
+            var validator = new NestedKeysValidator();
+            var files = new Dictionary<string, string>
+            {
+                {"manifests/some/other/key", ""}
+            };
+
+            await validator.Validate("manifests/a/b.json", async x => files[x]);
+        }
+        
+        [Fact]
+        public async Task FailsWhenParentKeyExists()
+        {
+            var validator = new NestedKeysValidator();
+            var files = new Dictionary<string, string>
+            {
+                {"manifests/a.json", ""}
+            };
+
+            await Assert.ThrowsAsync<NestedKeysException>(() =>
+                validator.Validate("manifests/a/b.json", async x => files[x]));
+        }
+    }
+}


### PR DESCRIPTION
Prevented users from adding a key under an already existing key, which causes inconsistencies in tweek-repo and shouldn't happen anyway.
Currently it's half-blocked in the editor UI itself, but under some cirumstances around archiving, it can reach an inconsistent state and still let users create such keys.
This PR mitigates that on the Publishing side.
