### PR TITLE
Api standalone improvements

### DIFF
--- a/addons/Rules/Tweek.Drivers.Rules.FileSystem/FileSystemRulesDriver.cs
+++ b/addons/Rules/Tweek.Drivers.Rules.FileSystem/FileSystemRulesDriver.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -10,27 +9,19 @@ namespace Tweek.Drivers.Rules.FileSystem
 {
   public class FileSystemRulesDriver : IRulesDriver
   {
-    private readonly string directoryPath;
+    private readonly string filePath;
 
-    public FileSystemRulesDriver(string directoryPathInput) => directoryPath = directoryPathInput;
+    public FileSystemRulesDriver(string filePathInput) => filePath = filePathInput;
 
-    public async Task<string> GetVersion(CancellationToken cancellationToken = default(CancellationToken))
+    public Task<string> GetVersion(CancellationToken cancellationToken = default(CancellationToken))
     {
-      var json = await readFile("versions", cancellationToken);
-      var versions = JObject.Parse(json);
-      return versions["latest"].Value<string>();
+      return Task.FromResult(filePath);
     }
 
     public async Task<Dictionary<string, RuleDefinition>> GetRuleset(string version, CancellationToken cancellationToken = default(CancellationToken))
     {
-      var json = await readFile(version, cancellationToken);
+      var json = await File.ReadAllTextAsync(filePath, cancellationToken);
       return JsonConvert.DeserializeObject<Dictionary<string, RuleDefinition>>(json);
-    }
-
-    private Task<string> readFile(string fileName, CancellationToken cancellationToken)
-    {
-      var filePath = Path.Combine(directoryPath, fileName);
-      return File.ReadAllTextAsync(filePath, cancellationToken);
     }
   }
 }

--- a/addons/Rules/Tweek.Drivers.Rules.FileSystem/RulesFileSystemAddon.cs
+++ b/addons/Rules/Tweek.Drivers.Rules.FileSystem/RulesFileSystemAddon.cs
@@ -15,9 +15,9 @@ namespace Tweek.Drivers.Rules.FileSystem
         public void Configure(IServiceCollection services, IConfiguration configuration)
         {
             var fileSystemConfiguration = configuration.GetSection("Rules:FileSystem");
-            var directoryPath = fileSystemConfiguration.GetValue<string>("DirectoryPath");
+            var filePath = fileSystemConfiguration.GetValue<string>("FilePath");
 
-            services.AddSingleton<IRulesDriver>(new FileSystemRulesDriver(directoryPath));
+            services.AddSingleton<IRulesDriver>(new FileSystemRulesDriver(filePath));
         }
     }
 }

--- a/docs/pages/5.deployment/04.configuration/01.api.md
+++ b/docs/pages/5.deployment/04.configuration/01.api.md
@@ -68,7 +68,7 @@ For File System provider, add the following configuration:
 
 ```
 UseAddon__Rules: FileSystemRules
-Rules__FileSystem__DirectoryPath: /var/rules
+Rules__FileSystem__FilePath: /var/rules/rules_file
 ```
 
 ### Monitoring

--- a/services/api/Tweek.ApiService/Controllers/KeysController.cs
+++ b/services/api/Tweek.ApiService/Controllers/KeysController.cs
@@ -61,7 +61,23 @@ namespace Tweek.ApiService.Controllers
         [ProducesResponseType(typeof(void), (int)HttpStatusCode.Forbidden)]
         [Produces("application/json")]
         [ApiExplorerSettings(IgnoreApi = true)]
-        public async Task<ActionResult> GetAsync([FromRoute] string path)
+        public Task<ActionResult> GetAsync([FromRoute] string path)
+        {
+            return GetKey(path);
+        }
+
+        [HttpGet("api/v1/keys")]
+        [HttpGet("api/v2/values")]
+        [ProducesResponseType(typeof(object), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.Forbidden)]
+        [Produces("application/json")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public Task<ActionResult> GetFromQueryAsync([FromQuery] string keyPath)
+        {
+            return GetKey(keyPath);
+        }
+
+        private async Task<ActionResult> GetKey(string path)
         {
             var allParams = PartitionByKey(HttpContext.Request.Query.ToDictionary(x => x.Key, x => x.Value), x => x.StartsWith("$"));
             var modifiers = allParams.Item1;


### PR DESCRIPTION
- FileSystemRulesDriver now takes a file path as env var input and no longer requires a versions file
- api/v2/values and api/v1/keys now support the keyPath query param instead of giving the path to the key as part of the url path

Addresses https://github.com/Soluto/tweek/pull/1333#pullrequestreview-487216930