### PR TITLE
Fix missing return statement in authRouter.go

### DIFF
--- a/services/gateway/security/authRouter.go
+++ b/services/gateway/security/authRouter.go
@@ -60,6 +60,7 @@ func authorizeByUserPassword(keyEnv *appConfig.EnvInlineOrPath, basicAuthConfig 
 			}
 			if !utils.ContainsString(basicAuthConfig.RedirectURLs, redirectURL.Scheme+"://"+redirectURL.Host) {
 				http.Error(w, "Redirect URL is invalid", http.StatusBadRequest)
+				return
 			}
 
 			state := requestQuery.Get("state")


### PR DESCRIPTION
Fix missing return statement, currently token is generated but not send to the client. We should abort the middleware on redirect-uri validation failure