### PR TITLE
fix avatar UI bug

### DIFF
--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-editor",
-  "version": "1.0.0-rc17",
+  "version": "1.0.0-rc18",
   "main": "dist/index.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/editor/src/components/JPadFullEditor/JPadVisualEditor/Matcher/Properties/Avatar.js
+++ b/services/editor/src/components/JPadFullEditor/JPadVisualEditor/Matcher/Properties/Avatar.js
@@ -15,7 +15,12 @@ function getAvatarText(identity) {
   let i = 1;
   while (i < identity.length) {
     const result = identity.substring(0, i).toLowerCase();
-    if (!lowerNames.some((n) => n.startsWith(result))) return result;
+    if (!lowerNames.some((n) => n.startsWith(result))) {
+      if (result.length > 1) {
+        return result.slice(0,1).concat(result.slice(-1));
+      }
+      else return result;
+    }
     i++;
   }
   return identity;

--- a/services/gateway/version.go
+++ b/services/gateway/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "1.0.0-rc17"
+const Version = "1.0.0-rc18"


### PR DESCRIPTION
if result is long use only the differentiating letters - first and last - 
so for example - if we have two identities that start with the same thing - "company_customer" and "company_employee" - then we will get the avatars as "cc" and "ce" respectively - to prevent the UI bug which overlapps the text by the avatar string.
this way the string will always be 1 or 2 charachters long.