### PR TITLE
Make json key editor resizable

### DIFF
--- a/services/editor/package.json
+++ b/services/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweek-editor",
-  "version": "1.0.0-rc18",
+  "version": "1.0.0-rc19",
   "main": "dist/index.js",
   "repository": "Soluto/tweek",
   "author": "Soluto",

--- a/services/editor/src/components/alerts/Alerts.js
+++ b/services/editor/src/components/alerts/Alerts.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withState, setDisplayName, compose } from 'recompose';
@@ -30,6 +31,7 @@ const Alert = addState(
     onClose,
     showCloseButton = false,
     componentData,
+    resizable = false,
     setComponentData,
   }) => (
     <Rodal
@@ -37,7 +39,7 @@ const Alert = addState(
       visible
       showCloseButton={showCloseButton}
       onClose={onClose}
-      className={'rodal-container'}
+      className={classNames('rodal-container', { resizable })}
     >
       {title && reactify(title, { className: 'rodal-header' })}
       {message && reactify(message, { className: 'rodal-body' })}

--- a/services/editor/src/components/alerts/Alerts.less
+++ b/services/editor/src/components/alerts/Alerts.less
@@ -2,6 +2,13 @@
   color: #555;
   line-height: 1.42857143;
 
+  &.resizable .rodal-dialog {
+    resize: both;
+    overflow: auto;
+    min-width: 500px;
+    min-height: 400px;
+  }
+
   .rodal-header {
     font-size: 16px;
     padding-bottom: 10px;
@@ -24,24 +31,27 @@
       margin: 0 5px;
       padding: 4px 15px;
       border-radius: 3px;
-      transition: background .2s;
+      transition: background 0.2s;
       border: 1px solid #03a9f4;
     }
 
-    .rodal-confirm-btn, .rodal-save-btn, .auto-partition-btn {
+    .rodal-confirm-btn,
+    .rodal-save-btn,
+    .auto-partition-btn {
       color: #fff;
       background: #03a9f4;
       &:hover {
         background: #0098e3;
       }
-      &:disabled{
+      &:disabled {
         background: #dddddd;
         border: 1px solid #cccccc;
-        color:#888888;
+        color: #888888;
       }
     }
 
-    .rodal-cancel-btn, .reset-partitions-btn {
+    .rodal-cancel-btn,
+    .reset-partitions-btn {
       color: #03a9f4;
       background: #fff;
       &:hover {

--- a/services/editor/src/components/common/Input/EditJSON.js
+++ b/services/editor/src/components/common/Input/EditJSON.js
@@ -81,6 +81,7 @@ export const withJsonEditor = compose(
             )}
           </AutoSizer>
         ),
+        resizable: true,
         buttons: [saveButton, buttons.CANCEL],
       };
 


### PR DESCRIPTION
### What

This PR introduces a way to make Alert dialogs resizable.

### Why

Editing Object/Array-typed keys is not the best experience.

Reasons I can think of are:
1. The modal is too small
2. There's no way to provide schema-based validation, which would allow auto-completion and help prevent errors.

This PR focuses on the modal size problem.

### How

It does so by adding a `resizable` flag to `showCustomAlert` (which is off by default for backward compatibility),

And applying a class to the modal container.

The class applies styling as suggested in [this SO post](https://stackoverflow.com/questions/47017753/monaco-editor-dynamically-resizable).
Also, it provides more sensible min-width & min-height.

### Notes

The `resizable` flag is currently only used in `EditJSON`.