### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,55 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:focal
+ENV SHELL=/usr/bin/zsh
+
+## Set docker-in-docker
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+ARG ENABLE_NONROOT_DOCKER="true"
+# [Option] Use the OSS Moby Engine instead of the licensed Docker Engine
+ARG USE_MOBY="true"
+
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN wget https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/docker-in-docker-debian.sh
+RUN bash ./docker-in-docker-debian.sh
+
+VOLUME [ "/var/lib/docker" ]
+RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz | \
+    tar zxvf - --strip 1 -C /usr/bin docker/docker
+    
+RUN sed -i "/plugins=/c\plugins=(docker git golang dotnet)" /home/vscode/.zshrc
+RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+
+### Installing dotnet 5.0
+RUN apt update; \
+    apt install -y apt-transport-https && \
+    apt update && \
+    apt install -y dotnet-sdk-5.0
+
+### Installing golang 1.14
+RUN curl -L https://golang.org/dl/go1.14.linux-amd64.tar.gz | sudo tar -xz -C /usr/local
+ENV PATH=$PATH:/usr/local/go/bin:/home/vscode/go/bin
+ENV GO111MODULE=on
+RUN apt-get install -y gccgo
+USER vscode
+RUN go get -v golang.org/x/tools/gopls \
+              github.com/ramya-rao-a/go-outline 
+USER root
+
+### Install nodejs & Yarn
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt install -y nodejs gcc g++ make
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt update && apt install -y yarn
+
+### Install Tilt
+RUN curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+RUN npm i -g zx
+
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,10 +10,6 @@ ARG ENABLE_NONROOT_DOCKER="true"
 # [Option] Use the OSS Moby Engine instead of the licensed Docker Engine
 ARG USE_MOBY="true"
 
-ARG USERNAME=automatic
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 RUN wget https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/docker-in-docker-debian.sh
 RUN bash ./docker-in-docker-debian.sh
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/docker-in-docker
+{
+	"name": "Tweek DevContainer",
+	"dockerFile": "Dockerfile",
+	"runArgs": ["--init", "--privileged"],
+	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
+	"overrideCommand": false,
+	
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"golang.go",
+		"ms-dotnettools.csharp",
+		"esbenp.prettier-vscode"
+	],
+	"postCreateCommand": [".devcontainer/install-all-deps"],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "docker --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,29 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/docker-in-docker
 {
-	"name": "Tweek DevContainer",
-	"dockerFile": "Dockerfile",
-	"runArgs": ["--init", "--privileged"],
-	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
-	"overrideCommand": false,
-	
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-azuretools.vscode-docker",
-		"golang.go",
-		"ms-dotnettools.csharp",
-		"esbenp.prettier-vscode"
-	],
-	"postCreateCommand": [".devcontainer/install-all-deps"],
-	
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  "name": "Tweek DevContainer",
+  "dockerFile": "Dockerfile",
+  "runArgs": ["--init", "--privileged"],
+  "mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
+  "overrideCommand": false,
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "docker --version",
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-azuretools.vscode-docker",
+    "golang.go",
+    "ms-dotnettools.csharp",
+    "esbenp.prettier-vscode"
+  ],
+  "postCreateCommand": [".devcontainer/install-all-deps"],
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8081],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "docker --version",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
 }

--- a/.devcontainer/install-all-deps
+++ b/.devcontainer/install-all-deps
@@ -6,7 +6,7 @@ try
   console.log(chalk.blue('Installing packages for all projects'))
   await Promise.all([$`dotnet restore ./Tweek.sln`, $`cd services/editor && yarn`])
   await Promise.all([$`cd services/publishing && dotnet restore ./Tweek.Publishing.sln`, $`cd services/authoring && yarn`])
-  await Promise.all([$`cd e2e/integration && yarn`, $`cd e2e/ui && yarn`])
+  await Promise.all([$`cd e2e/integration && yarn`, $`cd e2e/ui && yarn`, $`yarn`])
   console.log(chalk.green('All packages installed'))
 } catch (ex){
   console.log(chalk.red('Not all packages successfully loaded, try rerunning the script'))

--- a/.devcontainer/install-all-deps
+++ b/.devcontainer/install-all-deps
@@ -1,0 +1,13 @@
+#!/usr/bin/env zx
+try
+{
+  console.log(chalk.blue('Pulling Docker images'))
+  await $`docker-compose -f deployments/dev/tilt.yml pull --parallel`
+  console.log(chalk.blue('Installing packages for all projects'))
+  await Promise.all([$`dotnet restore ./Tweek.sln`, $`cd services/editor && yarn`])
+  await Promise.all([$`cd services/publishing && dotnet restore ./Tweek.Publishing.sln`, $`cd services/authoring && yarn`])
+  await Promise.all([$`cd e2e/integration && yarn`, $`cd e2e/ui && yarn`])
+  console.log(chalk.green('All packages installed'))
+} catch (ex){
+  console.log(chalk.red('Not all packages successfully loaded, try rerunning the script'))
+}

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,6 @@
 docker_compose("./deployments/dev/tilt.yml" )
-docker_build("soluto/tweek-gateway", "services/gateway")
+docker_build("soluto/tweek-gateway", "services/gateway",dockerfile="services/gateway/debug.Dockerfile")
+
 docker_build("soluto/tweek-authoring", "services/authoring")
 docker_build("soluto/tweek-api",  ".", dockerfile="TweekApi.Dockerfile")
 docker_build("soluto/tweek-publishing", "services/publishing")

--- a/services/gateway/debug.Dockerfile
+++ b/services/gateway/debug.Dockerfile
@@ -1,22 +1,16 @@
-# -------- DEPENDENCIES -------- #
-FROM golang:1.11.4-stretch as build
+# syntax = docker/dockerfile:1.2
+FROM golang:1.16.3-stretch as build
+WORKDIR /app
 
-ADD go.mod /src/go.mod
-ADD go.sum /src/go.sum
-WORKDIR /src
+ADD go.mod /app/go.mod
+ADD go.sum /app/go.sum
 
-RUN go mod download
+RUN --mount=id=tweek-gateway-pkgcache,type=cache,target=/go/pkg/mod go mod download -x
+ADD . /app
 
-ADD . /src
-WORKDIR /src
-
-RUN go build -o entry \
+RUN --mount=id=tweek-gateway-build-cache,type=cache,target=/root/.cache/go-build --mount=id=tweek-gateway-pkgcache,type=cache,target=/go/pkg/mod go build -o entry \
     && go test -cover -v ./...
 
-RUN go build -o hcheck "tweek-gateway/healthcheck"
-
-VOLUME [ "/config" ]
-
-RUN go get github.com/pilu/fresh
-
-ENTRYPOINT fresh
+RUN --mount=id=tweek-gateway-build-cache,type=cache,target=/root/.cache/go-build go build -o hcheck "tweek-gateway/healthcheck"
+HEALTHCHECK --interval=5s --timeout=2s --retries=10 CMD ["/app/healthcheck"]
+ENTRYPOINT [ "/app/entry" ]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -30,7 +30,7 @@ build:
     sync:
       manual:
       - src: '**/*.go'
-        dest: /src
+        dest: /app
     docker:
       dockerfile: debug.Dockerfile
   - image: soluto/tweek-editor


### PR DESCRIPTION
Enable fast developer onboarding for Tweek repo.
This can be used with vscode remote container feature and with GH codespaces.

The dev-container include:
- Nested Docker
- Dotnet and Golang sdks
- Node, yarn, zx
- Tilt
- Extensions for c#, GoLang, prettier 

Checked running the app, changing code and running all tests (include e2e).
Works with codespaces as well, but stills require VSCode desktop connectivity for login to work properly. (due to port-forwarding running on ***-**.github.dev that is not a valid redirect-uri for either the gateway or the oidc mock server)
