### PR TITLE
Merge Soluto/RadixTree into Tweek.Engine

### DIFF
--- a/core/Engine/Tweek.Engine.Tests/Collections/RadixTreeTests.cs
+++ b/core/Engine/Tweek.Engine.Tests/Collections/RadixTreeTests.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Tweek.Engine.Collections.Tests
+{
+    public class RadixTreeTests
+    {
+        [Fact]
+        public void Insert_ExistingKey_Replaces()
+        {
+            //Arrange
+            var expectedTree = new Dictionary<string, int>
+            {
+                [""] = 2,
+                ["a"] = 1,
+            };
+            var radixTree = InitTree(expectedTree.Keys, 1);
+
+            //Act
+            var (oldValue, updated) = radixTree.Insert("", 2);
+
+            //Assert
+            Assert.True(updated, "key should be updated");
+            Assert.Equal(1, oldValue);
+            Assert.Equal(expectedTree.Count, radixTree.Count);
+            Assert.Equal(expectedTree.Keys, radixTree.Keys);
+            Assert.Equal(expectedTree, radixTree.ToDictionary());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        [InlineData(10000)]
+        public void Insert_NotExistingKey_Adds(int count)
+        {
+            //Arrange
+            var expectedTree = Enumerable.Range(0, count).ToDictionary(_ => Guid.NewGuid().ToString(), x => x);
+            var radixTree = new RadixTree<int>();
+
+            foreach (var item in expectedTree)
+            {
+                // Act
+                var (_, updated) = radixTree.Insert(item.Key, item.Value);
+
+                // Assert
+                Assert.False(updated);
+            }
+
+            Assert.Equal(expectedTree.Count, radixTree.Count);
+            Assert.Equal(expectedTree.Keys, radixTree.Keys);
+            Assert.Equal(expectedTree, radixTree.ToDictionary());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("A")]
+        [InlineData("AB")]
+        public void Delete_ExistingKey_Deleted(string keyToDelete)
+        {
+            // Arrange
+            var keys = new[] { "", "A", "AB" };
+            var radixTree = InitTree(keys, 1);
+
+            // Act
+            var (val, ok) = radixTree.Delete(keyToDelete);
+
+            // Assert
+            Assert.True(ok, "Key should be removed");
+            Assert.Equal(1, val);
+            Assert.Equal(keys.Length - 1, radixTree.Count);
+            Assert.Equal(keys.Where(x => x != keyToDelete), radixTree.Keys.OrderBy(x => x));
+        }
+
+        [Theory]
+        [InlineData("C")]
+        [InlineData("AC")]
+        [InlineData("ABC")]
+        public void Delete_NotExistingKey_NoChange(string keyToDelete)
+        {
+            // Arrange
+            var keys = new[] { "", "A", "AB" };
+            var radixTree = InitTree(keys, 1);
+
+            // Act
+            var (_, ok) = radixTree.Delete(keyToDelete);
+
+            // Assert
+            Assert.False(ok, "Key should not be removed");
+            Assert.Equal(keys.Length, radixTree.Count);
+            Assert.Equal(keys, radixTree.Keys.OrderBy(x => x));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("A")]
+        public void Delete_EmptyTree_NoChange(string keyToDelete)
+        {
+            // Arrange
+            var radixTree = new RadixTree<int>();
+
+            // Act
+            var (_, ok) = radixTree.Delete(keyToDelete);
+
+            // Assert
+            Assert.False(ok, "Key should not be removed");
+            Assert.Equal(0, radixTree.Count);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("foo")]
+        public void TryGetValue_ExistingKey_ReturnsValue(string input)
+        {
+            // Arrange
+            var rand = new Random();
+            var keys = new[] {
+                "",
+                "foo",
+            };
+            var dictionary = keys.ToDictionary(x => x, _ => rand.Next());
+            var radixTree = new RadixTree<int>(dictionary);
+
+            // Act
+            var found = radixTree.TryGetValue(input, out int value);
+
+            // Assert
+            Assert.True(found, "should find value");
+            Assert.Equal(dictionary[input], value);
+        }
+
+        [Theory]
+        [InlineData("fo")]
+        [InlineData("b")]
+        [InlineData("foobar")]
+        [InlineData("barfoo")]
+        public void TryGetValue_NotExistingKey_NotFound(string input)
+        {
+            // Arrange
+            var radixTree = InitTree(new[] { "foo", "bar" }, 1);
+
+            // Act
+            var found = radixTree.TryGetValue(input, out int _);
+
+            // Assert
+            Assert.False(found, "should not find value");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        public void TryGetValue_EmptyTree_NotFound(string input)
+        {
+            // Arrange
+            var radixTree = new RadixTree<int>();
+
+            // Act
+            var found = radixTree.TryGetValue(input, out int _);
+
+            // Assert
+            Assert.False(found, "should not find value");
+        }
+
+        [Theory]
+        [InlineData("a", "")]
+        [InlineData("abc", "")]
+        [InlineData("fo", "")]
+        [InlineData("foo", "foo")]
+        [InlineData("foob", "foo")]
+        [InlineData("foobar", "foobar")]
+        [InlineData("foobarba", "foobar")]
+        [InlineData("foobarbaz", "foobarbaz")]
+        [InlineData("foobarbazzi", "foobarbaz")]
+        [InlineData("foobarbazzip", "foobarbazzip")]
+        [InlineData("foozi", "foo")]
+        [InlineData("foozip", "foozip")]
+        [InlineData("foozipzap", "foozip")]
+        public void LongestPrefix_ExistingPrefix_ReturnsValue(string input, string expected)
+        {
+            // Arrange
+            var rand = new Random();
+            var keys = new[] {
+                "",
+                "foo",
+                "foobar",
+                "foobarbaz",
+                "foobarbazzip",
+                "foozip",
+            };
+            var dictionary = keys.ToDictionary(x => x, _ => rand.Next());
+            var radixTree = new RadixTree<int>(dictionary);
+
+            // Act
+            var (key, value, found) = radixTree.LongestPrefix(input);
+
+            // Assert
+            Assert.True(found, "should find longest prefix match");
+            Assert.Equal(expected, key);
+            Assert.Equal(dictionary[expected], value);
+        }
+
+        [Theory]
+        [InlineData("a")]
+        [InlineData("abc")]
+        [InlineData("fo")]
+        [InlineData("oo")]
+        [InlineData("bar")]
+        public void LongestPrefix_NonExistingPrefix_NotFound(string input)
+        {
+            // Arrange
+            var keys = new[]
+            {
+                "foo",
+                "foobar",
+                "foobarbaz",
+                "foobarbazzip",
+                "foozip"
+            };
+            var radixTree = InitTree(keys, 1);
+
+            // Act
+            var (_, _, found) = radixTree.LongestPrefix(input);
+
+            // Assert
+            Assert.False(found, "should not find longest prefix match");
+
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        public void LongestPrefix_EmptyTree_NotFound(string input)
+        {
+            // Arrange
+            var radixTree = new RadixTree<int>();
+
+            // Act
+            var (_, _, found) = radixTree.LongestPrefix(input);
+
+            // Assert
+            Assert.False(found, "should not find longest prefix match");
+        }
+
+        [Theory]
+        [InlineData("f", new[] { "foobar", "foo/bar/baz", "foo/baz/bar", "foo/zip/zap" })]
+        [InlineData("foo", new[] { "foobar", "foo/bar/baz", "foo/baz/bar", "foo/zip/zap" })]
+        [InlineData("foob", new[] { "foobar" })]
+        [InlineData("foo/", new[] { "foo/bar/baz", "foo/baz/bar", "foo/zip/zap" })]
+        [InlineData("foo/b", new[] { "foo/bar/baz", "foo/baz/bar" })]
+        [InlineData("foo/ba", new[] { "foo/bar/baz", "foo/baz/bar" })]
+        [InlineData("foo/bar", new[] { "foo/bar/baz" })]
+        [InlineData("foo/bar/baz", new[] { "foo/bar/baz" })]
+        [InlineData("foo/bar/bazoo", new string[] { })]
+        [InlineData("z", new[] { "zipzap" })]
+        public void ListPrefix(string input, string[] expected)
+        {
+            // Arrange
+            var keys = new[]
+            {
+                "foobar",
+                "foo/bar/baz",
+                "foo/zip/zap",
+                "zipzap",
+                "foo/baz/bar"
+            };
+            var r = InitTree(keys, 1);
+
+            // Act
+            var result = r.ListPrefix(input);
+
+            // Assert
+            Assert.Equal(expected.Select(x => (x, 1)).OrderBy(x => x).ToList(), result);
+        }
+
+        private static RadixTree<T> InitTree<T>(IEnumerable<string> keys, T initialValue) => new RadixTree<T>(keys.ToDictionary(x => x, _ => initialValue));
+    }
+}

--- a/core/Engine/Tweek.Engine/Collections/LeafNode.cs
+++ b/core/Engine/Tweek.Engine/Collections/LeafNode.cs
@@ -1,0 +1,11 @@
+﻿namespace Tweek.Engine.Collections
+{
+    /// <summary>
+    /// Represents a value
+    /// </summary>
+    internal class LeafNode<TValue>
+    {
+        internal string Key = string.Empty;
+        internal TValue Value;
+    }
+}

--- a/core/Engine/Tweek.Engine/Collections/Node.cs
+++ b/core/Engine/Tweek.Engine/Collections/Node.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace Tweek.Engine.Collections
+{
+    internal class Node<TValue>
+    {
+        /// <summary>
+        /// Used to store possible leaf
+        /// </summary>
+        internal LeafNode<TValue> Leaf;
+
+        /// <summary>
+        /// The common prefix we ignore
+        /// </summary>
+        internal string Prefix = string.Empty;
+
+        /// <summary>
+        /// Edges should be stored in-order for iteration.
+        /// We avoid a fully materialized slice to save memory,
+        /// since in most cases we expect to be sparse
+        /// </summary>
+        internal SortedList<char, Node<TValue>> Edges = new SortedList<char, Node<TValue>>();
+
+        public bool IsLeaf => Leaf != null;
+
+        public void AddEdge(char label, Node<TValue> node)
+        {
+            Edges.Add(label, node);
+        }
+
+        public void SetEdge(char label, Node<TValue> node)
+        {
+            Edges[label] = node;
+        }
+
+        public bool TryGetEdge(char label, out Node<TValue> edge)
+        {
+            return Edges.TryGetValue(label, out edge);
+        }
+
+        public void RemoveEdge(char label)
+        {
+            Edges.Remove(label);
+        }
+
+        public void MergeChild()
+        {
+            var child = Edges.Values[0];
+
+            Prefix = Prefix + child.Prefix;
+            Leaf = child.Leaf;
+            Edges = child.Edges;
+        }
+
+        public void Clear()
+        {
+            Leaf = null;
+            Prefix = string.Empty;
+            Edges.Clear();
+        }
+    }
+}

--- a/core/Engine/Tweek.Engine/Collections/RadixTree.cs
+++ b/core/Engine/Tweek.Engine/Collections/RadixTree.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tweek.Engine.Collections
+{
+    /// <summary>
+    /// Tree implements a radix tree. This can be treated as a Dictionary abstract data type. 
+    /// The main advantage over a standard hash map is prefix-based lookups and ordered iteration.
+    /// </summary>
+    internal class RadixTree<TValue>
+    {
+        private delegate void Walker(string key, TValue value);
+
+        private readonly Node<TValue> _root = new Node<TValue>();
+        private readonly Dictionary<string, TValue> _values = new Dictionary<string, TValue>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadixTree{TValue}"/> class.
+        /// returns an empty Tree
+        /// </summary>
+        public RadixTree() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RadixTree{TValue}"/> class.
+        /// returns a new tree containing the keys from an existing map
+        /// </summary>
+        /// <param name="map"></param>
+        public RadixTree(IReadOnlyDictionary<string, TValue> map)
+        {
+            if (map == null)
+                throw new ArgumentNullException(nameof(map));
+
+            foreach (var kv in map)
+            {
+                Insert(kv.Key, kv.Value);
+            }
+        }
+
+        /// <summary>
+        /// The number of elements in the tree
+        /// </summary>
+        public int Count => _values.Count;
+
+        /// <summary>
+        /// Add a new entry or updates an existing entry
+        /// </summary>
+        /// <returns>is entry updated, and old value if it was</returns>
+        public (TValue oldValue, bool updated) Insert(string key, TValue value)
+        {
+            _values[key] = value;
+
+            var node = _root;
+            var search = key;
+
+            while (true)
+            {
+                // Handle key exhaution
+                if (search.Length == 0)
+                {
+                    if (node.IsLeaf)
+                    {
+                        var old = node.Leaf.Value;
+                        node.Leaf.Value = value;
+                        return (old, true);
+                    }
+
+                    node.Leaf = new LeafNode<TValue>
+                    {
+                        Key = key,
+                        Value = value,
+                    };
+                    return (default(TValue), false);
+                }
+
+                var parent = node;
+
+                // Look for the edge
+                // No edge, create one
+                if (!node.TryGetEdge(search[0], out node))
+                {
+                    parent.AddEdge(search[0], new Node<TValue>
+                    {
+                        Leaf = new LeafNode<TValue>
+                        {
+                            Key = key,
+                            Value = value,
+                        },
+                        Prefix = search,
+                    });
+                    return (default(TValue), false);
+                }
+
+                // Determine longest prefix of the search key on match
+                var commonPrefix = FindLongestPrefix(search, node.Prefix);
+                if (commonPrefix == node.Prefix.Length)
+                {
+                    search = search.Substring(commonPrefix);
+                    continue;
+                }
+
+                // Split the node
+                var child = new Node<TValue>
+                {
+                    Prefix = search.Substring(0, commonPrefix),
+                };
+                parent.SetEdge(search[0], child);
+
+                // Restore the existing node
+                child.AddEdge(node.Prefix[commonPrefix], node);
+                node.Prefix = node.Prefix.Substring(commonPrefix);
+
+                // Create a new leaf node
+                var leaf = new LeafNode<TValue>
+                {
+                    Key = key,
+                    Value = value,
+                };
+
+                // If the new key is a subset, add to to this node
+                search = search.Substring(commonPrefix);
+                if (search.Length == 0)
+                {
+                    child.Leaf = leaf;
+                    return (default(TValue), false);
+                }
+
+                // Create a new edge for the node
+                child.AddEdge(search[0], new Node<TValue>
+                {
+                    Leaf = leaf,
+                    Prefix = search,
+                });
+                return (default(TValue), false);
+            }
+        }
+
+        /// <summary>
+        /// Delete a key
+        /// </summary>
+        /// <returns>is entry deleted, and the value what was deleted</returns>
+        public (TValue oldValue, bool deleted) Delete(string key)
+        {
+            if (!_values.Remove(key)) return (default(TValue), false);
+
+            Node<TValue> parent = null;
+            var label = char.MinValue;
+            var node = _root;
+            var search = key;
+
+            while (true)
+            {
+                // Check for key exhaution
+                if (search.Length == 0)
+                {
+                    if (!node.IsLeaf)
+                        break;
+
+                    // Delete the leaf
+                    var leaf = node.Leaf;
+                    node.Leaf = null;
+
+                    // Check if we should delete this node from the parent
+                    if (parent != null && node.Edges.Count == 0)
+                        parent.RemoveEdge(label);
+
+                    // Check if we should merge this node
+                    if (node != _root && node.Edges.Count == 1)
+                        node.MergeChild();
+
+                    // Check if we should merge the parent's other child
+                    if (parent != null && parent != _root && parent.Edges.Count == 1 && !parent.IsLeaf)
+                        parent.MergeChild();
+
+                    return (leaf.Value, true);
+                }
+
+                // Look for an edge
+                parent = node;
+                label = search[0];
+                if (!node.TryGetEdge(label, out node))
+                    break;
+
+                // Consume the search prefix
+                if (search.StartsWith(node.Prefix))
+                    search = search.Substring(node.Prefix.Length);
+                else
+                    break;
+            }
+
+            return (default(TValue), false);
+        }
+
+        /// <summary>
+        /// Lookup a specific key.
+        /// </summary>
+        /// <returns>The value and if it was found</returns>
+        public bool TryGetValue(string key, out TValue value) => _values.TryGetValue(key, out value);
+
+        /// <summary>
+        /// Search for the longest prefix match.
+        /// </summary>
+        public (string key, TValue value, bool found) LongestPrefix(string prefix)
+        {
+            LeafNode<TValue> last = null;
+            var node = _root;
+            var search = prefix;
+
+            //for {
+            while (true)
+            {
+                // Look for a leaf node
+                if (node.IsLeaf)
+                    last = node.Leaf;
+
+                // Check for key exhaution
+                if (search.Length == 0)
+                    break;
+
+                // Look for an edge
+                if (!node.TryGetEdge(search[0], out node))
+                    break;
+
+                // Consume the search prefix
+                if (search.StartsWith(node.Prefix))
+                    search = search.Substring(node.Prefix.Length);
+                else
+                    break;
+            }
+
+            return last != null ? (last.Key, last.Value, true) : (string.Empty, default(TValue), false);
+        }
+
+        /// <summary>
+        /// Walk the tree under a prefix
+        /// </summary>
+        private void WalkPrefix(string prefix, Walker walker)
+        {
+            var node = _root;
+            var search = prefix;
+
+            while (true)
+            {
+                // Check for key exhaution
+                if (search.Length == 0)
+                {
+                    RecursiveWalk(node, walker);
+                    return;
+                }
+
+                // Look for an edge
+                if (!node.TryGetEdge(search[0], out node))
+                    break;
+
+                // Consume the search prefix
+                if (search.StartsWith(node.Prefix))
+                {
+                    search = search.Substring(node.Prefix.Length);
+                }
+                else if (node.Prefix.StartsWith(search))
+                {
+                    RecursiveWalk(node, walker);
+                    return;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Do a pre-order walk of a node recursively
+        /// </summary>
+        /// <returns>true if the walk should be aborted</returns>
+        private static void RecursiveWalk(Node<TValue> node, Walker walker)
+        {
+            // Visit the leaf values if any
+            if (node.Leaf != null)
+            {
+                walker(node.Leaf.Key, node.Leaf.Value);
+            }
+
+            // Recurse on the children
+            foreach (var edge in node.Edges.Values)
+            {
+                RecursiveWalk(edge, walker);
+            }
+        }
+
+        public Dictionary<string, TValue> ToDictionary() => new Dictionary<string, TValue>(_values);
+
+        public List<(string key, TValue value)> ListPrefix(string prefix)
+        {
+            var result = new List<(string, TValue)>();
+            WalkPrefix(prefix, (k, v) => result.Add((k, v)));
+            return result;
+        }
+
+        public ICollection<string> Keys => _values.Keys;
+
+        /// <summary>
+        /// Find the length of the shared prefix of two strings
+        /// </summary>
+        /// <param name="str1">first string to compare</param>
+        /// <param name="str2">secont string to compare</param>
+        /// <returns>length of shared prefix</returns>
+        private static int FindLongestPrefix(string str1, string str2)
+        {
+            var max = str1.Length > str2.Length ? str2.Length : str1.Length;
+
+            for (var i = 0; i < max; i++)
+                if (str1[i] != str2[i])
+                    return i;
+
+            return max;
+        }
+    }
+}

--- a/core/Engine/Tweek.Engine/Rules/Creation/RulesLoader.cs
+++ b/core/Engine/Tweek.Engine/Rules/Creation/RulesLoader.cs
@@ -1,5 +1,4 @@
 ﻿using LanguageExt;
-using Soluto.Collections;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +8,7 @@ using Tweek.Engine.Core.Rules;
 using Tweek.Engine.Core.Utils;
 using Tweek.Engine.DataTypes;
 using Tweek.Engine.Drivers.Rules;
+using Tweek.Engine.Collections;
 
 namespace Tweek.Engine.Rules.Creation
 {

--- a/core/Engine/Tweek.Engine/Tweek.Engine.csproj
+++ b/core/Engine/Tweek.Engine/Tweek.Engine.csproj
@@ -5,11 +5,13 @@
   <ItemGroup>
     <PackageReference Include="FSharpUtils.Newtonsoft.JsonValue" Version="0.2.6" />
     <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
-    <PackageReference Include="Soluto.Collections.RadixTree" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tweek.Engine.Core\Tweek.Engine.Core.csproj" />
     <ProjectReference Include="..\Tweek.Engine.DataTypes\Tweek.Engine.DataTypes.csproj" />
     <ProjectReference Include="..\Tweek.Engine.Drivers\Tweek.Engine.Drivers.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+	<InternalsVisibleTo Include="Tweek.Engine.Tests"/>	
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Soluto/RadixTree repository was depublished from NuGet some time ago, which means that Tweek currently depends on an unpublished and deprecated NuGet library.

This change copies RadixTree into the Tweek.Engine library as an internal class. RadixTree is not used anywhere outside of this one reference.